### PR TITLE
DFU support (Phase 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ set(COMMON_SOURCES
         ${CMAKE_CURRENT_LIST_DIR}/src/led.c
         ${CMAKE_CURRENT_LIST_DIR}/src/uart.c
         ${CMAKE_CURRENT_LIST_DIR}/src/usb.c
+        ${CMAKE_CURRENT_LIST_DIR}/src/hid.c
+        ${CMAKE_CURRENT_LIST_DIR}/src/dfu.c
         ${CMAKE_CURRENT_LIST_DIR}/src/main.c
         ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/pio_usb/dcd_pio_usb.c
         ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
@@ -62,13 +64,14 @@ set(COMMON_LINK_LIBRARIES
   hardware_gpio
   hardware_pio
 
-  tinyusb_device 
+  tinyusb_device
   tinyusb_host
   pico_multicore
   Pico-PIO-USB
+  pico_unique_id
 )
 
-# Pico A - Keyboard (board_role = 0) 
+# Pico A - Keyboard (board_role = 0)
 #      B - Mouse    (board_role = 1)
 
 set(binaries board_A board_B)

--- a/DFU.md
+++ b/DFU.md
@@ -1,0 +1,231 @@
+# Device Firmware Update over USB
+
+DeskHop devices support [USB DFU (Device Firmware
+Update)](https://en.wikipedia.org/wiki/USB#Device_Firmware_Upgrade_mechanism)
+version
+[1.1](https://web.archive.org/web/20141011015811/http://www.usb.org/developers/docs/devclass_docs/DFU_1.1.pdf). DFU
+can be used to both upload (device to host) and download (host to
+device) firmware and configuration data.
+
+## Tools and modes
+
+There are a variety of DFU tools available for various platforms. The
+DeskHop implementation has been tested with [dfu-util version
+0.11](https://dfu-util.sourceforge.net/). This tool is available as a
+regular package in most Linux distributions; it can be installed on
+macOS using Homebrew; and it can be installed on Windows using
+packages from the project site.
+
+All of the examples in this documentation use `dfu-util` but the
+commands can be adapted to other tools.
+
+On Linux systems, `dfu-util` requires root access, or sufficient
+permissions to the USB devices to allow raw USB data transfers.
+
+DFU operates in two modes: 'runtime' and 'transfer'.
+
+### 'runtime' mode
+
+DFU 'runtime' mode is an additional feature available during DeskHop's
+normal operation (as a USB HID). This mode allows the host software to
+trigger a switch to DFU 'transfer' mode in order to initiate uploads or
+downloads. Because this can introduce a security concern, it is
+disabled by default but can be enabled by setting `DFU_RT_ENABLED` to
+`1` in `user_config.h` when building the DeskHop firmware.
+
+### 'transfer' mode
+
+DFU 'transfer' mode allows uploads and downloads. It can be entered from
+DFU 'runtime' mode by using a DFU host tool to trigger a `DETACH`
+operation, or by using the key sequences `Left Shift-Right Shift-F12-C`
+(for board A) and `Left Shift-Right Shift-F12-D` (for board B).
+
+Once this mode has been entered, the DeskHop will stay in the mode for
+a maximum of 30 seconds, or until an upload or download has been
+completed. Also note that once this mode has been entered on a board
+the normal operation of that board (keyboard or mouse input, and
+output to the host) will stop. Alternative input device(s) will need
+to be connected to the host in order to issue commands to execute the
+DFU transfer operations.
+
+## Firwmare management with 'runtime' mode
+
+### Backup/Archive
+
+To backup the firmware from a DeskHop device:
+
+(command run on host connected to board A)
+
+```shell
+$ dfu-util -a board_a_fw -d 2E8A:107C -U firmware_a.bin
+```
+
+(command run on host connected to board B)
+
+```shell
+$ dfu-util -a board_b_fw -d 2E8A:107C -U firmware_b.bin
+```
+
+These commands will switch the DeskHop into DFU 'transfer' mode,
+upload the firmware from the DeskHop's flash memory, and then the
+DeskHop will reboot back into normal operation.
+
+### Upgrade
+
+To upgrade the firmware on a DeskHop device:
+
+(command run on host connected to board A)
+
+```shell
+$ dfu-util -a board_a_fw -d 2E8A:107C -D board_A.bin
+```
+
+(command run on host connected to board B)
+
+```shell
+$ dfu-util -a board_b_fw -d 2E8A:107C -U board_B.bin
+```
+
+The firmware filenames listed above are the usual names produced by
+the DeskHop firmware build process; do not attempt to upload the
+`.uf2`, `.elf`, or `.hex` versions of the firmware file, as doing so
+will result in a non-operational DeskHop board and recovery will
+require using the `BOOTSEL` button to boot the board into USB recovery
+mode.
+
+These commands will switch the DeskHop into DFU 'transfer' mode,
+download the firmware into the DeskHop's flash memory, and then the
+DeskHop will reboot back into normal operation.
+
+## Firwmare management without 'runtime' mode
+
+### Backup/Archive
+
+To backup the firmware from a DeskHop device, switch one of the
+DeskHop boards into 'transfer' mode using the key sequence documented
+above. Within 30 seconds:
+
+(command run on host connected to board A)
+
+```shell
+$ dfu-util -a board_a_fw -d 2E8A:XXXX -U firmware_a.bin
+```
+
+(command run on host connected to board B)
+
+```shell
+$ dfu-util -a board_b_fw -d 2E8A:XXXX -U firmware_b.bin
+```
+
+These commands will upload the firmware from the DeskHop's flash
+memory, and then the DeskHop will reboot back into normal operation.
+
+### Upgrade
+
+To upgrade the firmware on a DeskHop device, switch one of the DeskHop
+boards into 'transfer' mode using the key sequence documented
+above. Within 30 seconds:
+
+(command run on host connected to board A)
+
+```shell
+$ dfu-util -a board_a_fw -d 2E8A:107C -D board_A.bin
+```
+
+(command run on host connected to board B)
+
+```shell
+$ dfu-util -a board_b_fw -d 2E8A:107C -U board_B.bin
+```
+
+The firmware filenames listed above are the usual names produced by
+the DeskHop firmware build process; do not attempt to upload the
+`.uf2`, `.elf`, or `.hex` versions of the firmware file, as doing so
+will result in a non-operational DeskHop board and recovery will
+require using the `BOOTSEL` button to boot the board into USB recovery
+mode.
+
+These commands will download the firmware into the DeskHop's flash
+memory, and then the DeskHop will reboot back into normal operation.
+
+## Configuration management with 'runtime' mode
+
+### Backup
+
+To backup the configuration from a DeskHop device:
+
+(command run on host connected to either board, since they have
+identical configurations)
+
+```shell
+$ dfu-util -a config -d 2E8A:107C -U config.bin
+```
+
+This command will switch the DeskHop into DFU 'transfer' mode, upload
+the configuration from the DeskHop's flash memory, and then the
+DeskHop will reboot back into normal operation.
+
+Note that the configuration data is a binary data structure; it is not
+human-readable and there are no tools available to convert it into a
+human-readable format.
+
+### Restore
+
+To restore the configuration on a DeskHop device (must be done for
+both boards):
+
+(command run on host connected to board A)
+
+```shell
+$ dfu-util -a config -d 2E8A:107C -D config.bin
+```
+
+(command run on host connected to board B)
+
+```shell
+$ dfu-util -a config -d 2E8A:107C -D config.bin
+```
+
+This command will switch the DeskHop into DFU 'transfer' mode,
+download the configuration into the DeskHop's flash memory, and then
+the DeskHop will reboot back into normal operation.
+
+## Configuration management without 'runtime' mode
+
+### Backup/Archive
+
+To backup the configuration from a DeskHop device, switch one of the
+DeskHop boards into 'transfer' mode using the key sequence documented
+above. Within 30 seconds:
+
+(command run on host connected to the board in 'transfer' mode, since
+they have identical configurations)
+
+```shell
+$ dfu-util -a config -d 2E8A:XXXX -U config.bin
+```
+
+This command will upload the configuration from the DeskHop's flash
+memory, and then the DeskHop will reboot back into normal operation.
+
+Note that the configuration data is a binary data structure; it is not
+human-readable and there are no tools available to convert it into a
+human-readable format.
+
+### Restore
+
+To restore the configurartion on a DeskHop device, switch one of the DeskHop
+boards into 'transfer' mode using the key sequence documented
+above. Within 30 seconds:
+
+(command run on host connected to the board in 'transfer' mode)
+
+```shell
+$ dfu-util -a config -d 2E8A:XXXX -D config.bin
+```
+
+This command will download the configuration into the DeskHop's flash
+memory, and then the DeskHop will reboot back into normal operation.
+
+Repeat this sequence for the other board in the DeskHop device so that
+the configuration on the boards will be identical.

--- a/memory_map.ld
+++ b/memory_map.ld
@@ -21,12 +21,23 @@
     __stack (== StackTop)
 */
 
-__CONFIG_STORAGE_LEN = 4k;
+__FLASH_START = 0x10000000;
+__FLASH_SIZE = 2048k;
+
+__CONFIG_STORAGE_SIZE = 4k;
+__DFU_BUFFER_SIZE = 512k;
+
+__PROGRAM_ORIGIN = __FLASH_START;
+__CONFIG_ORIGIN = __FLASH_START + (__FLASH_SIZE - __CONFIG_STORAGE_SIZE);
+__DFU_BUFFER_ORIGIN = __PROGRAM_ORIGIN + 512k;
+
+__PROGRAM_MAX_SIZE = __DFU_BUFFER_ORIGIN - __PROGRAM_ORIGIN;
 
 MEMORY
 {
-    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 2048k - __CONFIG_STORAGE_LEN
-    FLASH_CONFIG(rw) : ORIGIN = 0x10000000 + (2048k - __CONFIG_STORAGE_LEN), LENGTH = __CONFIG_STORAGE_LEN
+    PROGRAM(rx) : ORIGIN = __PROGRAM_ORIGIN, LENGTH = __PROGRAM_MAX_SIZE
+    CONFIG(r) : ORIGIN = __CONFIG_ORIGIN, LENGTH = __CONFIG_STORAGE_SIZE
+    DFU_BUFFER(r) : ORIGIN = __DFU_BUFFER_ORIGIN, LENGTH = __DFU_BUFFER_SIZE
     RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 256k
     SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
@@ -43,13 +54,13 @@ SECTIONS
 
     .flash_begin : {
         __flash_binary_start = .;
-    } > FLASH
+    } > PROGRAM
 
     .boot2 : {
         __boot2_start__ = .;
         KEEP (*(.boot2))
         __boot2_end__ = .;
-    } > FLASH
+    } > PROGRAM
 
     ASSERT(__boot2_end__ - __boot2_start__ == 256,
         "ERROR: Pico second stage bootloader must be 256 bytes in size")
@@ -73,18 +84,18 @@ SECTIONS
         /* segments not marked as .flashdata are instead pulled into .data (in RAM) to avoid accidental flash accesses */
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
-    } > FLASH
+    } > PROGRAM
 
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > FLASH
+    } > PROGRAM
 
     __exidx_start = .;
     .ARM.exidx :
     {
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > FLASH
+    } > PROGRAM
     __exidx_end = .;
 
     /* Machine inspectable binary information */
@@ -94,7 +105,7 @@ SECTIONS
     {
         KEEP(*(.binary_info.keep.*))
         *(.binary_info.*)
-    } > FLASH
+    } > PROGRAM
     __binary_info_end = .;
     . = ALIGN(4);
 
@@ -124,7 +135,7 @@ SECTIONS
         *(.eh_frame*)
         . = ALIGN(4);
         __ram_text_end__ = .;
-    } > RAM AT> FLASH
+    } > RAM AT> PROGRAM
     __ram_text_source__ = LOADADDR(.text);
     . = ALIGN(4);
 
@@ -174,7 +185,7 @@ SECTIONS
         . = ALIGN(4);
         /* All data end */
         __data_end__ = .;
-    } > RAM AT> FLASH
+    } > RAM AT> PROGRAM
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
 
@@ -189,7 +200,7 @@ SECTIONS
         *(.scratch_x.*)
         . = ALIGN(4);
         __scratch_x_end__ = .;
-    } > SCRATCH_X AT > FLASH
+    } > SCRATCH_X AT > PROGRAM
     __scratch_x_source__ = LOADADDR(.scratch_x);
 
     .scratch_y : {
@@ -197,7 +208,7 @@ SECTIONS
         *(.scratch_y.*)
         . = ALIGN(4);
         __scratch_y_end__ = .;
-    } > SCRATCH_Y AT > FLASH
+    } > SCRATCH_Y AT > PROGRAM
     __scratch_y_source__ = LOADADDR(.scratch_y);
 
     .bss  : {
@@ -216,12 +227,6 @@ SECTIONS
         KEEP(*(.heap*))
         __HeapLimit = .;
     } > RAM
-
-    /* Configuration flash section (4k in size, end of flash) */
-    
-    .section_config : {
-        "ADDR_CONFIG" = .;  
-    } > FLASH_CONFIG
 
     /* .stack*_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
@@ -243,7 +248,8 @@ SECTIONS
 
     .flash_end : {
         __flash_binary_end = .;
-    } > FLASH
+	__PROGRAM_END = .;
+    } > PROGRAM
 
     /* stack limit is poorly named, but historically is maximum heap ptr */
     __StackLimit = ORIGIN(RAM) + LENGTH(RAM);

--- a/pico-sdk/lib/tinyusb/hw/bsp/rp2040/family.cmake
+++ b/pico-sdk/lib/tinyusb/hw/bsp/rp2040/family.cmake
@@ -71,6 +71,8 @@ target_sources(tinyusb_device_base INTERFACE
 		${TOP}/src/device/usbd_control.c
 		${TOP}/src/class/cdc/cdc_device.c
 		${TOP}/src/class/hid/hid_device.c
+		${TOP}/src/class/dfu/dfu_device.c
+		${TOP}/src/class/dfu/dfu_rt_device.c
 		)
 
 #------------------------------------

--- a/pico-sdk/lib/tinyusb/src/CMakeLists.txt
+++ b/pico-sdk/lib/tinyusb/src/CMakeLists.txt
@@ -23,6 +23,9 @@ function(add_tinyusb TARGET)
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/class/vendor/vendor_host.c
     # typec
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/typec/usbc.c
+    # dfu
+    ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/class/dfu/dfu_device.c
+    ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/class/dfu/dfu_rt_device.c
     )
   target_include_directories(${TARGET} PUBLIC
     ${CMAKE_CURRENT_FUNCTION_LIST_DIR}

--- a/pico-sdk/lib/tinyusb/src/class/dfu/dfu.h
+++ b/pico-sdk/lib/tinyusb/src/class/dfu/dfu.h
@@ -1,0 +1,119 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 XMOS LIMITED
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef _TUSB_DFU_H_
+#define _TUSB_DFU_H_
+
+#include "common/tusb_common.h"
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Common Definitions
+//--------------------------------------------------------------------+
+
+// DFU Protocol
+typedef enum
+{
+  DFU_PROTOCOL_RT  = 0x01,
+  DFU_PROTOCOL_DFU = 0x02,
+} dfu_protocol_type_t;
+
+// DFU Descriptor Type
+typedef enum
+{
+  DFU_DESC_FUNCTIONAL = 0x21,
+} dfu_descriptor_type_t;
+
+// DFU Requests
+typedef enum {
+  DFU_REQUEST_DETACH         = 0,
+  DFU_REQUEST_DNLOAD         = 1,
+  DFU_REQUEST_UPLOAD         = 2,
+  DFU_REQUEST_GETSTATUS      = 3,
+  DFU_REQUEST_CLRSTATUS      = 4,
+  DFU_REQUEST_GETSTATE       = 5,
+  DFU_REQUEST_ABORT          = 6,
+} dfu_requests_t;
+
+// DFU States
+typedef enum {
+  APP_IDLE                   = 0,
+  APP_DETACH                 = 1,
+  DFU_IDLE                   = 2,
+  DFU_DNLOAD_SYNC            = 3,
+  DFU_DNBUSY                 = 4,
+  DFU_DNLOAD_IDLE            = 5,
+  DFU_MANIFEST_SYNC          = 6,
+  DFU_MANIFEST               = 7,
+  DFU_MANIFEST_WAIT_RESET    = 8,
+  DFU_UPLOAD_IDLE            = 9,
+  DFU_ERROR                  = 10,
+} dfu_state_t;
+
+// DFU Status
+typedef enum {
+  DFU_STATUS_OK               = 0x00,
+  DFU_STATUS_ERR_TARGET       = 0x01,
+  DFU_STATUS_ERR_FILE         = 0x02,
+  DFU_STATUS_ERR_WRITE        = 0x03,
+  DFU_STATUS_ERR_ERASE        = 0x04,
+  DFU_STATUS_ERR_CHECK_ERASED = 0x05,
+  DFU_STATUS_ERR_PROG         = 0x06,
+  DFU_STATUS_ERR_VERIFY       = 0x07,
+  DFU_STATUS_ERR_ADDRESS      = 0x08,
+  DFU_STATUS_ERR_NOTDONE      = 0x09,
+  DFU_STATUS_ERR_FIRMWARE     = 0x0A,
+  DFU_STATUS_ERR_VENDOR       = 0x0B,
+  DFU_STATUS_ERR_USBR         = 0x0C,
+  DFU_STATUS_ERR_POR          = 0x0D,
+  DFU_STATUS_ERR_UNKNOWN      = 0x0E,
+  DFU_STATUS_ERR_STALLEDPKT   = 0x0F,
+} dfu_status_t;
+
+#define DFU_ATTR_CAN_DOWNLOAD              (1u << 0)
+#define DFU_ATTR_CAN_UPLOAD                (1u << 1)
+#define DFU_ATTR_MANIFESTATION_TOLERANT    (1u << 2)
+#define DFU_ATTR_WILL_DETACH               (1u << 3)
+
+// DFU Status Request Payload
+typedef struct TU_ATTR_PACKED
+{
+  uint8_t bStatus;
+  uint8_t bwPollTimeout[3];
+  uint8_t bState;
+  uint8_t iString;
+} dfu_status_response_t;
+
+TU_VERIFY_STATIC( sizeof(dfu_status_response_t) == 6, "size is not correct");
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_DFU_H_ */

--- a/pico-sdk/lib/tinyusb/src/class/dfu/dfu_device.c
+++ b/pico-sdk/lib/tinyusb/src/class/dfu/dfu_device.c
@@ -1,0 +1,460 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 XMOS LIMITED
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "tusb_option.h"
+
+#if (CFG_TUD_ENABLED && CFG_TUD_DFU)
+
+#include "device/usbd.h"
+#include "device/usbd_pvt.h"
+
+#include "dfu_device.h"
+
+//--------------------------------------------------------------------+
+// MACRO CONSTANT TYPEDEF
+//--------------------------------------------------------------------+
+
+//--------------------------------------------------------------------+
+// INTERNAL OBJECT & FUNCTION DECLARATION
+//--------------------------------------------------------------------+
+typedef struct
+{
+  uint8_t attrs;
+  uint8_t alt;
+
+  dfu_state_t state;
+  dfu_status_t status;
+
+  bool flashing_in_progress;
+  uint16_t block;
+  uint16_t length;
+
+  CFG_TUSB_MEM_ALIGN uint8_t transfer_buf[CFG_TUD_DFU_XFER_BUFSIZE];
+} dfu_state_ctx_t;
+
+// Only a single dfu state is allowed
+CFG_TUSB_MEM_SECTION static dfu_state_ctx_t _dfu_ctx;
+
+static void reset_state(void)
+{
+  _dfu_ctx.state = DFU_IDLE;
+  _dfu_ctx.status = DFU_STATUS_OK;
+  _dfu_ctx.flashing_in_progress = false;
+}
+
+static bool reply_getstatus(uint8_t rhport, tusb_control_request_t const * request, dfu_state_t state, dfu_status_t status, uint32_t timeout);
+static bool process_download_get_status(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
+static bool process_manifest_get_status(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
+
+//--------------------------------------------------------------------+
+// Debug
+//--------------------------------------------------------------------+
+#if CFG_TUSB_DEBUG >= 2
+
+static tu_lookup_entry_t const _dfu_request_lookup[] =
+{
+  { .key = DFU_REQUEST_DETACH         , .data = "DETACH"    },
+  { .key = DFU_REQUEST_DNLOAD         , .data = "DNLOAD"    },
+  { .key = DFU_REQUEST_UPLOAD         , .data = "UPLOAD"    },
+  { .key = DFU_REQUEST_GETSTATUS      , .data = "GETSTATUS" },
+  { .key = DFU_REQUEST_CLRSTATUS      , .data = "CLRSTATUS" },
+  { .key = DFU_REQUEST_GETSTATE       , .data = "GETSTATE"  },
+  { .key = DFU_REQUEST_ABORT          , .data = "ABORT"     },
+};
+
+static tu_lookup_table_t const _dfu_request_table =
+{
+  .count = TU_ARRAY_SIZE(_dfu_request_lookup),
+  .items = _dfu_request_lookup
+};
+
+static tu_lookup_entry_t const _dfu_state_lookup[] =
+{
+  { .key = APP_IDLE                   , .data = "APP_IDLE"                },
+  { .key = APP_DETACH                 , .data = "APP_DETACH"              },
+  { .key = DFU_IDLE                   , .data = "IDLE"                },
+  { .key = DFU_DNLOAD_SYNC            , .data = "DNLOAD_SYNC"         },
+  { .key = DFU_DNBUSY                 , .data = "DNBUSY"              },
+  { .key = DFU_DNLOAD_IDLE            , .data = "DNLOAD_IDLE"         },
+  { .key = DFU_MANIFEST_SYNC          , .data = "MANIFEST_SYNC"       },
+  { .key = DFU_MANIFEST               , .data = "MANIFEST"            },
+  { .key = DFU_MANIFEST_WAIT_RESET    , .data = "MANIFEST_WAIT_RESET" },
+  { .key = DFU_UPLOAD_IDLE            , .data = "UPLOAD_IDLE"         },
+  { .key = DFU_ERROR                  , .data = "ERROR"               },
+};
+
+static tu_lookup_table_t const _dfu_state_table =
+{
+  .count = TU_ARRAY_SIZE(_dfu_state_lookup),
+  .items = _dfu_state_lookup
+};
+
+static tu_lookup_entry_t const _dfu_status_lookup[] =
+{
+  { .key = DFU_STATUS_OK               , .data = "OK"              },
+  { .key = DFU_STATUS_ERR_TARGET       , .data = "errTARGET"       },
+  { .key = DFU_STATUS_ERR_FILE         , .data = "errFILE"         },
+  { .key = DFU_STATUS_ERR_WRITE        , .data = "errWRITE"        },
+  { .key = DFU_STATUS_ERR_ERASE        , .data = "errERASE"        },
+  { .key = DFU_STATUS_ERR_CHECK_ERASED , .data = "errCHECK_ERASED" },
+  { .key = DFU_STATUS_ERR_PROG         , .data = "errPROG"         },
+  { .key = DFU_STATUS_ERR_VERIFY       , .data = "errVERIFY"       },
+  { .key = DFU_STATUS_ERR_ADDRESS      , .data = "errADDRESS"      },
+  { .key = DFU_STATUS_ERR_NOTDONE      , .data = "errNOTDONE"      },
+  { .key = DFU_STATUS_ERR_FIRMWARE     , .data = "errFIRMWARE"     },
+  { .key = DFU_STATUS_ERR_VENDOR       , .data = "errVENDOR"       },
+  { .key = DFU_STATUS_ERR_USBR         , .data = "errUSBR"         },
+  { .key = DFU_STATUS_ERR_POR          , .data = "errPOR"          },
+  { .key = DFU_STATUS_ERR_UNKNOWN      , .data = "errUNKNOWN"      },
+  { .key = DFU_STATUS_ERR_STALLEDPKT   , .data = "errSTALLEDPKT"   },
+};
+
+static tu_lookup_table_t const _dfu_status_table =
+{
+  .count = TU_ARRAY_SIZE(_dfu_status_lookup),
+  .items = _dfu_status_lookup
+};
+
+#endif
+
+//--------------------------------------------------------------------+
+// USBD Driver API
+//--------------------------------------------------------------------+
+void dfu_moded_reset(uint8_t rhport)
+{
+  (void) rhport;
+
+  _dfu_ctx.attrs = 0;
+  _dfu_ctx.alt = 0;
+
+  reset_state();
+}
+
+void dfu_moded_init(void)
+{
+  dfu_moded_reset(0);
+}
+
+uint16_t dfu_moded_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len)
+{
+  (void) rhport;
+
+  //------------- Interface (with Alt) descriptor -------------//
+  uint8_t const itf_num = itf_desc->bInterfaceNumber;
+  uint8_t alt_count = 0;
+
+  uint16_t drv_len = 0;
+  TU_VERIFY(itf_desc->bInterfaceSubClass == TUD_DFU_APP_SUBCLASS && itf_desc->bInterfaceProtocol == DFU_PROTOCOL_DFU, 0);
+
+  while(itf_desc->bInterfaceSubClass == TUD_DFU_APP_SUBCLASS && itf_desc->bInterfaceProtocol == DFU_PROTOCOL_DFU)
+  {
+    TU_ASSERT(max_len > drv_len, 0);
+
+    // Alternate must have the same interface number
+    TU_ASSERT(itf_desc->bInterfaceNumber == itf_num, 0);
+
+    // Alt should increase by one every time
+    TU_ASSERT(itf_desc->bAlternateSetting == alt_count, 0);
+    alt_count++;
+
+    drv_len += tu_desc_len(itf_desc);
+    itf_desc = (tusb_desc_interface_t const *) tu_desc_next(itf_desc);
+  }
+
+  //------------- DFU Functional descriptor -------------//
+  tusb_desc_dfu_functional_t const *func_desc = (tusb_desc_dfu_functional_t const *) itf_desc;
+  TU_ASSERT(tu_desc_type(func_desc) == TUSB_DESC_FUNCTIONAL, 0);
+  drv_len += sizeof(tusb_desc_dfu_functional_t);
+
+  _dfu_ctx.attrs = func_desc->bAttributes;
+
+  // CFG_TUD_DFU_XFER_BUFSIZE has to be set to the buffer size used in TUD_DFU_DESCRIPTOR
+  uint16_t const transfer_size = tu_le16toh( tu_unaligned_read16((uint8_t const*) func_desc + offsetof(tusb_desc_dfu_functional_t, wTransferSize)) );
+  TU_ASSERT(transfer_size <= CFG_TUD_DFU_XFER_BUFSIZE, drv_len);
+
+  return drv_len;
+}
+
+// Invoked when a control transfer occurred on an interface of this class
+// Driver response accordingly to the request and the transfer stage (setup/data/ack)
+// return false to stall control endpoint (e.g unsupported request)
+bool dfu_moded_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request)
+{
+  TU_VERIFY(request->bmRequestType_bit.recipient == TUSB_REQ_RCPT_INTERFACE);
+
+  TU_LOG2("  DFU State  : %s, Status: %s\r\n", tu_lookup_find(&_dfu_state_table, _dfu_ctx.state), tu_lookup_find(&_dfu_status_table, _dfu_ctx.status));
+
+  if ( request->bmRequestType_bit.type == TUSB_REQ_TYPE_STANDARD )
+  {
+    // Standard request include GET/SET_INTERFACE
+    switch ( request->bRequest )
+    {
+      case TUSB_REQ_SET_INTERFACE:
+        if ( stage == CONTROL_STAGE_SETUP )
+        {
+          // Switch Alt interface and reset state machine
+          _dfu_ctx.alt = (uint8_t) request->wValue;
+          reset_state();
+          return tud_control_status(rhport, request);
+        }
+      break;
+
+      case TUSB_REQ_GET_INTERFACE:
+        if(stage == CONTROL_STAGE_SETUP)
+        {
+          return tud_control_xfer(rhport, request, &_dfu_ctx.alt, 1);
+        }
+      break;
+
+      // unsupported request
+      default: return false;
+    }
+  }
+  else if ( request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS )
+  {
+    TU_LOG2("  DFU Request: %s\r\n", tu_lookup_find(&_dfu_request_table, request->bRequest));
+
+    // Class request
+    switch ( request->bRequest )
+    {
+      case DFU_REQUEST_DETACH:
+        if ( stage == CONTROL_STAGE_SETUP )
+        {
+          tud_control_status(rhport, request);
+        }
+        else if ( stage == CONTROL_STAGE_ACK )
+        {
+          if ( tud_dfu_detach_cb ) tud_dfu_detach_cb();
+        }
+      break;
+
+      case DFU_REQUEST_CLRSTATUS:
+        if ( stage == CONTROL_STAGE_SETUP )
+        {
+          reset_state();
+          tud_control_status(rhport, request);
+        }
+      break;
+
+      case DFU_REQUEST_GETSTATE:
+        if ( stage == CONTROL_STAGE_SETUP )
+        {
+          tud_control_xfer(rhport, request, &_dfu_ctx.state, 1);
+        }
+      break;
+
+      case DFU_REQUEST_ABORT:
+        if ( stage == CONTROL_STAGE_SETUP )
+        {
+          reset_state();
+          tud_control_status(rhport, request);
+        }
+        else if ( stage == CONTROL_STAGE_ACK )
+        {
+          if ( tud_dfu_abort_cb ) tud_dfu_abort_cb(_dfu_ctx.alt);
+        }
+      break;
+
+      case DFU_REQUEST_UPLOAD:
+        if ( stage == CONTROL_STAGE_SETUP )
+        {
+          TU_VERIFY(_dfu_ctx.attrs & DFU_ATTR_CAN_UPLOAD);
+          TU_VERIFY(tud_dfu_upload_cb);
+          TU_VERIFY(request->wLength <= CFG_TUD_DFU_XFER_BUFSIZE);
+
+          uint16_t const xfer_len = tud_dfu_upload_cb(_dfu_ctx.alt, request->wValue, _dfu_ctx.transfer_buf, request->wLength);
+
+          return tud_control_xfer(rhport, request, _dfu_ctx.transfer_buf, xfer_len);
+        }
+      break;
+
+      case DFU_REQUEST_DNLOAD:
+        if ( stage == CONTROL_STAGE_SETUP )
+        {
+          TU_VERIFY(_dfu_ctx.attrs & DFU_ATTR_CAN_DOWNLOAD);
+          TU_VERIFY(_dfu_ctx.state == DFU_IDLE || _dfu_ctx.state == DFU_DNLOAD_IDLE);
+          TU_VERIFY(request->wLength <= CFG_TUD_DFU_XFER_BUFSIZE);
+
+          // set to true for both download and manifest
+          _dfu_ctx.flashing_in_progress = true;
+
+          // save block and length for flashing
+          _dfu_ctx.block  = request->wValue;
+          _dfu_ctx.length = request->wLength;
+
+          if ( request->wLength )
+          {
+            // Download with payload -> transition to DOWNLOAD SYNC
+            _dfu_ctx.state = DFU_DNLOAD_SYNC;
+            return tud_control_xfer(rhport, request, _dfu_ctx.transfer_buf, request->wLength);
+          }
+          else
+          {
+            // Download is complete -> transition to MANIFEST SYNC
+            _dfu_ctx.state = DFU_MANIFEST_SYNC;
+            return tud_control_status(rhport, request);
+          }
+        }
+      break;
+
+      case DFU_REQUEST_GETSTATUS:
+        switch ( _dfu_ctx.state )
+        {
+          case DFU_DNLOAD_SYNC:
+            return process_download_get_status(rhport, stage, request);
+          break;
+
+          case DFU_MANIFEST_SYNC:
+            return process_manifest_get_status(rhport, stage, request);
+          break;
+
+          default:
+            if ( stage == CONTROL_STAGE_SETUP ) return reply_getstatus(rhport, request, _dfu_ctx.state, _dfu_ctx.status, 0);
+          break;
+        }
+      break;
+
+      default: return false; // stall unsupported request
+    }
+  }else
+  {
+    return false; // unsupported request
+  }
+
+  return true;
+}
+
+void tud_dfu_finish_flashing(uint8_t status)
+{
+  _dfu_ctx.flashing_in_progress = false;
+
+  if ( status == DFU_STATUS_OK )
+  {
+    if (_dfu_ctx.state == DFU_DNBUSY)
+    {
+      _dfu_ctx.state = DFU_DNLOAD_SYNC;
+    }
+    else if (_dfu_ctx.state == DFU_MANIFEST)
+    {
+      _dfu_ctx.state = (_dfu_ctx.attrs & DFU_ATTR_MANIFESTATION_TOLERANT)
+                               ? DFU_MANIFEST_SYNC : DFU_MANIFEST_WAIT_RESET;
+    }
+  }
+  else
+  {
+    // failed while flashing, move to dfuError
+    _dfu_ctx.state = DFU_ERROR;
+    _dfu_ctx.status = (dfu_status_t)status;
+  }
+}
+
+static bool process_download_get_status(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request)
+{
+  if ( stage == CONTROL_STAGE_SETUP )
+  {
+    // only transition to next state on CONTROL_STAGE_ACK
+    dfu_state_t next_state;
+    uint32_t timeout;
+
+    if ( _dfu_ctx.flashing_in_progress )
+    {
+      next_state = DFU_DNBUSY;
+      timeout = tud_dfu_get_timeout_cb(_dfu_ctx.alt, (uint8_t) next_state);
+    }
+    else
+    {
+      next_state = DFU_DNLOAD_IDLE;
+      timeout = 0;
+    }
+
+    return reply_getstatus(rhport, request, next_state, _dfu_ctx.status, timeout);
+  }
+  else if ( stage == CONTROL_STAGE_ACK )
+  {
+    if ( _dfu_ctx.flashing_in_progress )
+    {
+      _dfu_ctx.state = DFU_DNBUSY;
+      tud_dfu_download_cb(_dfu_ctx.alt, _dfu_ctx.block, _dfu_ctx.transfer_buf, _dfu_ctx.length);
+    }else
+    {
+      _dfu_ctx.state = DFU_DNLOAD_IDLE;
+    }
+  }
+
+  return true;
+}
+
+static bool process_manifest_get_status(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request)
+{
+  if ( stage == CONTROL_STAGE_SETUP )
+  {
+    // only transition to next state on CONTROL_STAGE_ACK
+    dfu_state_t next_state;
+    uint32_t timeout;
+
+    if ( _dfu_ctx.flashing_in_progress )
+    {
+      next_state = DFU_MANIFEST;
+      timeout = tud_dfu_get_timeout_cb(_dfu_ctx.alt, next_state);
+    }
+    else
+    {
+      next_state = DFU_IDLE;
+      timeout = 0;
+    }
+
+    return reply_getstatus(rhport, request, next_state, _dfu_ctx.status, timeout);
+  }
+  else if ( stage == CONTROL_STAGE_ACK )
+  {
+    if ( _dfu_ctx.flashing_in_progress )
+    {
+      _dfu_ctx.state = DFU_MANIFEST;
+      tud_dfu_manifest_cb(_dfu_ctx.alt);
+    }
+    else
+    {
+      _dfu_ctx.state = DFU_IDLE;
+    }
+  }
+
+  return true;
+}
+
+static bool reply_getstatus(uint8_t rhport, tusb_control_request_t const * request, dfu_state_t state, dfu_status_t status, uint32_t timeout)
+{
+  dfu_status_response_t resp;
+  resp.bStatus          = (uint8_t) status;
+  resp.bwPollTimeout[0] = TU_U32_BYTE0(timeout);
+  resp.bwPollTimeout[1] = TU_U32_BYTE1(timeout);
+  resp.bwPollTimeout[2] = TU_U32_BYTE2(timeout);
+  resp.bState           = (uint8_t) state;
+  resp.iString          = 0;
+
+  return tud_control_xfer(rhport, request, &resp, sizeof(dfu_status_response_t));
+}
+
+#endif

--- a/pico-sdk/lib/tinyusb/src/class/dfu/dfu_device.h
+++ b/pico-sdk/lib/tinyusb/src/class/dfu/dfu_device.h
@@ -1,0 +1,98 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 XMOS LIMITED
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef _TUSB_DFU_DEVICE_H_
+#define _TUSB_DFU_DEVICE_H_
+
+#include "dfu.h"
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Class Driver Default Configure & Validation
+//--------------------------------------------------------------------+
+
+#if !defined(CFG_TUD_DFU_XFER_BUFSIZE)
+  #error "CFG_TUD_DFU_XFER_BUFSIZE must be defined, it has to be set to the buffer size used in TUD_DFU_DESCRIPTOR"
+#endif
+
+//--------------------------------------------------------------------+
+// Application API
+//--------------------------------------------------------------------+
+
+// Must be called when the application is done with flashing started by
+// tud_dfu_download_cb() and tud_dfu_manifest_cb().
+// status is DFU_STATUS_OK if successful, any other error status will cause state to enter dfuError
+void tud_dfu_finish_flashing(uint8_t status);
+
+//--------------------------------------------------------------------+
+// Application Callback API (weak is optional)
+//--------------------------------------------------------------------+
+
+// Note: alt is used as the partition number, in order to support multiple partitions like FLASH, EEPROM, etc.
+
+// Invoked right before tud_dfu_download_cb() (state=DFU_DNBUSY) or tud_dfu_manifest_cb() (state=DFU_MANIFEST)
+// Application return timeout in milliseconds (bwPollTimeout) for the next download/manifest operation.
+// During this period, USB host won't try to communicate with us.
+uint32_t tud_dfu_get_timeout_cb(uint8_t alt, uint8_t state);
+
+// Invoked when received DFU_DNLOAD (wLength>0) following by DFU_GETSTATUS (state=DFU_DNBUSY) requests
+// This callback could be returned before flashing op is complete (async).
+// Once finished flashing, application must call tud_dfu_finish_flashing()
+void tud_dfu_download_cb (uint8_t alt, uint16_t block_num, uint8_t const *data, uint16_t length);
+
+// Invoked when download process is complete, received DFU_DNLOAD (wLength=0) following by DFU_GETSTATUS (state=Manifest)
+// Application can do checksum, or actual flashing if buffered entire image previously.
+// Once finished flashing, application must call tud_dfu_finish_flashing()
+void tud_dfu_manifest_cb(uint8_t alt);
+
+// Invoked when received DFU_UPLOAD request
+// Application must populate data with up to length bytes and
+// Return the number of written bytes
+TU_ATTR_WEAK uint16_t tud_dfu_upload_cb(uint8_t alt, uint16_t block_num, uint8_t* data, uint16_t length);
+
+// Invoked when a DFU_DETACH request is received
+TU_ATTR_WEAK void tud_dfu_detach_cb(void);
+
+// Invoked when the Host has terminated a download or upload transfer
+TU_ATTR_WEAK void tud_dfu_abort_cb(uint8_t alt);
+
+//--------------------------------------------------------------------+
+// Internal Class Driver API
+//--------------------------------------------------------------------+
+void     dfu_moded_init(void);
+void     dfu_moded_reset(uint8_t rhport);
+uint16_t dfu_moded_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len);
+bool     dfu_moded_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
+
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_DFU_MODE_DEVICE_H_ */

--- a/pico-sdk/lib/tinyusb/src/class/dfu/dfu_rt_device.c
+++ b/pico-sdk/lib/tinyusb/src/class/dfu/dfu_rt_device.c
@@ -1,0 +1,128 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Sylvain Munaut <tnt@246tNt.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "tusb_option.h"
+
+#if (CFG_TUD_ENABLED && CFG_TUD_DFU_RUNTIME)
+
+#include "device/usbd.h"
+#include "device/usbd_pvt.h"
+
+#include "dfu_rt_device.h"
+
+//--------------------------------------------------------------------+
+// MACRO CONSTANT TYPEDEF
+//--------------------------------------------------------------------+
+
+//--------------------------------------------------------------------+
+// INTERNAL OBJECT & FUNCTION DECLARATION
+//--------------------------------------------------------------------+
+
+//--------------------------------------------------------------------+
+// USBD Driver API
+//--------------------------------------------------------------------+
+void dfu_rtd_init(void)
+{
+}
+
+void dfu_rtd_reset(uint8_t rhport)
+{
+    (void) rhport;
+}
+
+uint16_t dfu_rtd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len)
+{
+  (void) rhport;
+  (void) max_len;
+
+  // Ensure this is DFU Runtime
+  TU_VERIFY((itf_desc->bInterfaceSubClass == TUD_DFU_APP_SUBCLASS) &&
+            (itf_desc->bInterfaceProtocol == DFU_PROTOCOL_RT), 0);
+
+  uint8_t const * p_desc = tu_desc_next( itf_desc );
+  uint16_t drv_len = sizeof(tusb_desc_interface_t);
+
+  if ( TUSB_DESC_FUNCTIONAL == tu_desc_type(p_desc) )
+  {
+    drv_len += tu_desc_len(p_desc);
+    p_desc   = tu_desc_next(p_desc);
+  }
+
+  return drv_len;
+}
+
+// Invoked when a control transfer occurred on an interface of this class
+// Driver response accordingly to the request and the transfer stage (setup/data/ack)
+// return false to stall control endpoint (e.g unsupported request)
+bool dfu_rtd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request)
+{
+  // nothing to do with DATA or ACK stage
+  if ( stage != CONTROL_STAGE_SETUP ) return true;
+
+  TU_VERIFY(request->bmRequestType_bit.recipient == TUSB_REQ_RCPT_INTERFACE);
+
+  // dfu-util will try to claim the interface with SET_INTERFACE request before sending DFU request
+  if ( TUSB_REQ_TYPE_STANDARD == request->bmRequestType_bit.type &&
+       TUSB_REQ_SET_INTERFACE == request->bRequest )
+  {
+    tud_control_status(rhport, request);
+    return true;
+  }
+
+  // Handle class request only from here
+  TU_VERIFY(request->bmRequestType_bit.type == TUSB_REQ_TYPE_CLASS);
+
+  switch (request->bRequest)
+  {
+    case DFU_REQUEST_DETACH:
+    {
+      TU_LOG2("  DFU RT Request: DETACH\r\n");
+      tud_control_status(rhport, request);
+      tud_dfu_runtime_reboot_to_dfu_cb();
+    }
+    break;
+
+    case DFU_REQUEST_GETSTATUS:
+    {
+      TU_LOG2("  DFU RT Request: GETSTATUS\r\n");
+      dfu_status_response_t resp;
+      // Status = OK, Poll timeout is ignored during RT, State = APP_IDLE, IString = 0
+      memset(&resp, 0x00, sizeof(dfu_status_response_t));
+      tud_control_xfer(rhport, request, &resp, sizeof(dfu_status_response_t));
+    }
+    break;
+
+    default:
+    {
+      TU_LOG2("  DFU RT Unexpected Request: %d\r\n", request->bRequest);
+      return false; // stall unsupported request
+    }
+  }
+
+  return true;
+}
+
+#endif

--- a/pico-sdk/lib/tinyusb/src/class/dfu/dfu_rt_device.h
+++ b/pico-sdk/lib/tinyusb/src/class/dfu/dfu_rt_device.h
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Sylvain Munaut <tnt@246tNt.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef _TUSB_DFU_RT_DEVICE_H_
+#define _TUSB_DFU_RT_DEVICE_H_
+
+#include "dfu.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Application Callback API (weak is optional)
+//--------------------------------------------------------------------+
+// Invoked when a DFU_DETACH request is received and bitWillDetach is set
+void tud_dfu_runtime_reboot_to_dfu_cb(void);
+
+//--------------------------------------------------------------------+
+// Internal Class Driver API
+//--------------------------------------------------------------------+
+void     dfu_rtd_init(void);
+void     dfu_rtd_reset(uint8_t rhport);
+uint16_t dfu_rtd_open(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len);
+bool     dfu_rtd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request);
+
+#ifdef __cplusplus
+ }
+#endif
+
+#endif /* _TUSB_DFU_RT_DEVICE_H_ */

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -1,0 +1,313 @@
+/*
+ * This file is part of DeskHop (https://github.com/hrvach/deskhop).
+ * Copyright (c) 2024 Hrvoje Cavrak
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "main.h"
+#include "usb_descriptors.h"
+
+extern const uint8_t __PROGRAM_ORIGIN;
+extern const uint8_t __PROGRAM_END;
+
+extern const uint8_t __FLASH_START;
+
+extern const uint8_t __DFU_BUFFER_ORIGIN;
+
+extern const config_t __CONFIG_ORIGIN;
+
+static const uint8_t *dfu_buffer = &__DFU_BUFFER_ORIGIN;
+static size_t dfu_buffer_contents_size;
+
+static uint8_t flash_buf[FLASH_SECTOR_SIZE];
+
+//--------------------------------------------------------------------+
+// Device Descriptor
+//--------------------------------------------------------------------+
+
+tusb_desc_device_t const desc_device_dfu = {
+    .bLength         = sizeof(tusb_desc_device_t),
+    .bDescriptorType = TUSB_DESC_DEVICE,
+    .bcdUSB          = 0x0200,
+    .bDeviceClass    = 0x00,
+    .bDeviceSubClass = 0x00,
+    .bDeviceProtocol = 0x00,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+
+    // https://github.com/raspberrypi/usb-pid
+    .idVendor  = 0x2E8A,
+    .idProduct = 0x107C,   // TODO: will require a second PID for DFU mode
+    .bcdDevice = 0x0100,
+
+    .iManufacturer = 0x01,
+    .iProduct      = 0x02,
+    .iSerialNumber = 0x03,
+
+    .bNumConfigurations = 0x01};
+
+//--------------------------------------------------------------------+
+// Configuration Descriptor
+//--------------------------------------------------------------------+
+
+enum alt_num_e {
+    ALT_BOARD_A_FW = 0,
+    ALT_BOARD_B_FW,
+    ALT_CONFIG,
+    ALT_DFU_BUFFER,
+};
+
+#ifdef DFU_DEBUG
+#define ALT_COUNT 4
+#else
+#define ALT_COUNT 3
+#endif
+
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_DFU_DESC_LEN(ALT_COUNT))
+
+uint8_t const desc_configuration_dfu[] = {
+    // Config number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1,
+			  1,
+			  0,
+			  CONFIG_TOTAL_LEN,
+			  TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP,
+			  500),
+
+    // Interface number, Alternate count, starting string index, attributes, detach timeout, transfer size
+    TUD_DFU_DESCRIPTOR(0,
+		       ALT_COUNT,
+		       STRID_DFU_BOARD_A_FW,
+                       DFU_ATTR_CAN_DOWNLOAD | DFU_ATTR_CAN_UPLOAD | DFU_ATTR_WILL_DETACH,
+		       DFU_MAX_WAIT,
+		       CFG_TUD_DFU_XFER_BUFSIZE),
+};
+
+//--------------------------------------------------------------------+
+// Callbacks
+//--------------------------------------------------------------------+
+
+int64_t dfu_timeout_alarm_cb(alarm_id_t id, void *user_data) {
+    watchdog_reboot(0x00000000, 0x00000000, 50);
+
+    /* Wait for the reset */
+    while(true)
+        tight_loop_contents();
+}
+
+/* Invoked on DFU_DETACH request to reboot to the bootloader */
+void tud_dfu_runtime_reboot_to_dfu_cb(void)
+{
+    /* Indicate that the next boot should be into DFU mode */
+    watchdog_hw->scratch[0] = DFU_BOOT_MODE;
+    watchdog_reboot(0x00000000, 0x00000000, 50);
+
+    /* Wait for the reset */
+    while(true)
+        tight_loop_contents();
+}
+
+uint32_t tud_dfu_get_timeout_cb(uint8_t alt, uint8_t state)
+{
+   if (state == DFU_DNBUSY) {
+       /* 100ms for a 'sector erase' plus a 'sector program' */
+       return 100;
+   }
+
+   /* state == DFU_MANIFEST) */
+   /* 100ms per sector to be programmed */
+   return 100 * (1 + (dfu_buffer_contents_size / FLASH_SECTOR_SIZE));
+}
+
+void tud_dfu_download_cb(uint8_t alt, uint16_t block_num, uint8_t const* data, uint16_t length)
+{
+    const uint32_t flash_address = &__DFU_BUFFER_ORIGIN - &__FLASH_START + (block_num * FLASH_SECTOR_SIZE);
+
+    flash_range_erase(flash_address, FLASH_SECTOR_SIZE);
+
+    if (length == FLASH_SECTOR_SIZE) {
+	flash_range_program(flash_address, data, FLASH_SECTOR_SIZE);
+    } else {
+	memcpy(flash_buf, data, length);
+	flash_range_program(flash_address, flash_buf, FLASH_SECTOR_SIZE);
+    }
+
+    tud_dfu_finish_flashing(DFU_STATUS_OK);
+
+    dfu_buffer_contents_size += length;
+}
+
+static const uint8_t *download_destination_address = NULL;
+static size_t download_bytes_left;
+
+void prepare_firmware_download()
+{
+    download_destination_address = &__PROGRAM_ORIGIN;
+    download_bytes_left = dfu_buffer_contents_size;
+}
+
+void prepare_config_download()
+{
+    download_destination_address = (const uint8_t *) &__CONFIG_ORIGIN;
+    download_bytes_left = dfu_buffer_contents_size;
+}
+
+void local_manifest_cb()
+{
+    const uint8_t *source_address = dfu_buffer;
+    uint32_t flash_address = download_destination_address - &__FLASH_START;
+
+    while (download_bytes_left > 0) {
+	flash_range_erase(flash_address, FLASH_SECTOR_SIZE);
+
+	uint32_t bytes_to_copy = download_bytes_left >= FLASH_SECTOR_SIZE ? FLASH_SECTOR_SIZE : download_bytes_left;
+
+	memcpy(flash_buf, source_address, bytes_to_copy);
+	download_bytes_left -= bytes_to_copy;
+
+	flash_range_program(flash_address, flash_buf, FLASH_SECTOR_SIZE);
+	source_address += FLASH_SECTOR_SIZE;
+	flash_address += FLASH_SECTOR_SIZE;
+    }
+}
+
+void tud_dfu_manifest_cb(uint8_t alt)
+{
+    switch (alt) {
+    case ALT_BOARD_A_FW:
+	if (BOARD_ROLE == PICO_A) {
+	    prepare_firmware_download();
+	    local_manifest_cb();
+	}
+    case ALT_BOARD_B_FW:
+	if (BOARD_ROLE == PICO_B) {
+	    prepare_firmware_download();
+	    local_manifest_cb();
+	}
+    case ALT_CONFIG:
+	prepare_firmware_download();
+	local_manifest_cb();
+    }
+
+    tud_dfu_finish_flashing(DFU_STATUS_OK);
+
+#ifndef DFU_DEBUG
+    /* the manifest is complete, reboot in 1 second to
+       ensure that any remaining USB communications
+       have time to be completed */
+    add_alarm_in_ms(1000, dfu_timeout_alarm_cb, NULL, false);
+#endif
+}
+
+static const uint8_t *upload_source_address = NULL;
+static size_t upload_bytes_left;
+
+void prepare_firmware_upload()
+{
+    upload_source_address = &__PROGRAM_ORIGIN;
+    upload_bytes_left = &__PROGRAM_END - &__PROGRAM_ORIGIN;
+}
+
+void prepare_config_upload()
+{
+    upload_source_address = (uint8_t *) &global_state.config;
+    upload_bytes_left = sizeof(global_state.config);
+}
+
+void prepare_dfu_buffer_upload()
+{
+    upload_source_address = dfu_buffer;
+    upload_bytes_left = dfu_buffer_contents_size;
+}
+
+uint16_t local_upload_cb(uint8_t* data, uint16_t length)
+{
+    uint16_t bytes_to_send = (upload_bytes_left > length) ? length : upload_bytes_left;
+
+    memcpy(data, upload_source_address, bytes_to_send);
+
+    upload_source_address += bytes_to_send;
+    upload_bytes_left -= bytes_to_send;
+    if (upload_bytes_left == 0) {
+	upload_source_address = NULL;
+
+	/* the upload is complete, reboot in 1 second to
+	   ensure that any remaining USB communications
+	   have time to be completed */
+	add_alarm_in_ms(1000, dfu_timeout_alarm_cb, NULL, false);
+    }
+
+    return bytes_to_send;
+}
+
+uint16_t tud_dfu_upload_cb(uint8_t alt, uint16_t block_num, uint8_t* data, uint16_t length)
+{
+    switch (alt) {
+    case ALT_BOARD_A_FW:
+	if (BOARD_ROLE == PICO_A) {
+	    if (upload_source_address == NULL) {
+		prepare_firmware_upload();
+	    }
+	    return local_upload_cb(data, length);
+	} else {
+	    return 0;
+	}
+    case ALT_BOARD_B_FW:
+	if (BOARD_ROLE == PICO_B) {
+	    if (upload_source_address == NULL) {
+		prepare_firmware_upload();
+	    }
+	    return local_upload_cb(data, length);
+	} else {
+	    return 0;
+	}
+    case ALT_CONFIG:
+	if (upload_source_address == NULL) {
+	    prepare_config_upload();
+	}
+	return local_upload_cb(data, length);
+    case ALT_DFU_BUFFER:
+	if (upload_source_address == NULL) {
+	    prepare_dfu_buffer_upload();
+	}
+	return local_upload_cb(data, length);
+    }
+
+    return 0;
+}
+
+// Invoked when the Host has terminated a download or upload transfer
+void tud_dfu_abort_cb(uint8_t alt)
+{
+    switch (alt) {
+    case ALT_BOARD_A_FW:
+	if (BOARD_ROLE == PICO_A) {
+	    upload_source_address = NULL;
+	}
+	dfu_buffer_contents_size = 0;
+    case ALT_BOARD_B_FW:
+	if (BOARD_ROLE == PICO_B) {
+	    upload_source_address = NULL;
+	}
+	dfu_buffer_contents_size = 0;
+    case ALT_CONFIG:
+	upload_source_address = NULL;
+    case ALT_DFU_BUFFER:
+	upload_source_address = NULL;
+    }
+
+    /* restart the maximum wait timer for the next
+       upload or download */
+    cancel_alarm(global_state.dfu_timeout_alarm);
+    global_state.dfu_timeout_alarm = add_alarm_in_ms(DFU_MAX_WAIT, dfu_timeout_alarm_cb, NULL, false);
+}

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -61,6 +61,16 @@ void fw_upgrade_hotkey_handler_B(device_t *state, hid_keyboard_report_t *report)
     send_value(ENABLE, FIRMWARE_UPGRADE_MSG);
 };
 
+/* This key combo puts board A in DFU mode */
+void dfu_hotkey_handler_A(device_t *state, hid_keyboard_report_t *report) {
+    reboot_board(DFU_BOOT_MODE);
+};
+
+/* This key combo puts board B in DFU mode */
+void dfu_hotkey_handler_B(device_t *state, hid_keyboard_report_t *report) {
+    send_value(ENABLE, DFU_MSG);
+};
+
 /* This key combo prevents mouse from switching outputs */
 void switchlock_hotkey_handler(device_t *state, hid_keyboard_report_t *report) {
     state->switch_lock ^= 1;
@@ -179,6 +189,11 @@ void handle_output_select_msg(uart_packet_t *packet, device_t *state) {
 /* On firmware upgrade message, reboot into the BOOTSEL fw upgrade mode */
 void handle_fw_upgrade_msg(uart_packet_t *packet, device_t *state) {
     reset_usb_boot(1 << PICO_DEFAULT_LED_PIN, 0);
+}
+
+/* On DFU message, reboot into the DFU mode */
+void handle_dfu_msg(uart_packet_t *packet, device_t *state) {
+    reboot_board(DFU_BOOT_MODE);
 }
 
 /* Comply with request to turn mouse zoom mode on/off  */

--- a/src/hid.c
+++ b/src/hid.c
@@ -1,0 +1,177 @@
+/*
+ * This file is part of DeskHop (https://github.com/hrvach/deskhop).
+ * Copyright (c) 2024 Hrvoje Cavrak
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "main.h"
+#include "usb_descriptors.h"
+
+//--------------------------------------------------------------------+
+// Device Descriptor
+//--------------------------------------------------------------------+
+
+tusb_desc_device_t const desc_device_hid = {
+	.bLength         = sizeof(tusb_desc_device_t),
+	.bDescriptorType = TUSB_DESC_DEVICE,
+	.bcdUSB          = 0x0200,
+	.bDeviceClass    = 0x00,
+	.bDeviceSubClass = 0x00,
+	.bDeviceProtocol = 0x00,
+	.bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+
+	// https://github.com/raspberrypi/usb-pid
+	.idVendor  = 0x2E8A,
+	.idProduct = 0x107C,
+	.bcdDevice = 0x0100,
+
+	.iManufacturer = 0x01,
+	.iProduct      = 0x02,
+	.iSerialNumber = 0x03,
+
+	.bNumConfigurations = 0x01};
+
+//--------------------------------------------------------------------+
+// HID Report Descriptor
+//--------------------------------------------------------------------+
+
+enum itf_num_e {
+	ITF_NUM_HID,
+	ITF_NUM_HID_REL_M,
+#if DFU_RT_ENABLED
+	ITF_NUM_DFU_RT,
+#endif
+#ifdef DH_DEBUG
+	ITF_NUM_CDC,
+#endif
+	ITF_NUM_TOTAL
+};
+
+// Relative mouse is used to overcome limitations of multiple desktops on MacOS and Windows
+uint8_t const desc_hid_report[] = {TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(REPORT_ID_KEYBOARD)),
+                                   TUD_HID_REPORT_DESC_ABSMOUSE(HID_REPORT_ID(REPORT_ID_MOUSE))};
+
+uint8_t const desc_hid_report_relmouse[] = {TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(REPORT_ID_RELMOUSE))};
+
+// Invoked when received GET HID REPORT DESCRIPTOR
+// Application return pointer to descriptor
+// Descriptor contents must exist long enough for transfer to complete
+uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance) {
+    if (instance == ITF_NUM_HID_REL_M) {
+        return desc_hid_report_relmouse;
+    }
+
+    /* Default */
+    return desc_hid_report;
+}
+
+//--------------------------------------------------------------------+
+// Configuration Descriptor
+//--------------------------------------------------------------------+
+
+#define EPNUM_HID       0x81
+#define EPNUM_HID_REL_M 0x82
+
+#ifndef DH_DEBUG
+
+#if DFU_RT_ENABLED
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_HID_DESC_LEN + TUD_DFU_RT_DESC_LEN)
+#else
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_HID_DESC_LEN)
+#endif
+
+#else
+
+#if DFU_RT_ENABLED
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_HID_DESC_LEN + TUD_DFU_RT_DESC_LEN + TUD_CDC_DESC_LEN)
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_HID_DESC_LEN + TUD_CDC_DESC_LEN)
+#else
+#endif
+
+#define EPNUM_CDC_NOTIF  0x83
+#define EPNUM_CDC_OUT    0x04
+#define EPNUM_CDC_IN     0x84
+
+#endif
+
+uint8_t const desc_configuration_hid[] = {
+    // Config number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1,
+			  ITF_NUM_TOTAL,
+			  0,
+			  CONFIG_TOTAL_LEN,
+			  TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP,
+			  500),
+
+    // Interface number, string index, protocol, report descriptor len, EP In address, size & polling interval
+    TUD_HID_DESCRIPTOR(ITF_NUM_HID,
+                       STRID_PRODUCT,
+                       HID_ITF_PROTOCOL_NONE,
+                       sizeof(desc_hid_report),
+                       EPNUM_HID,
+                       CFG_TUD_HID_EP_BUFSIZE,
+                       1),
+
+    TUD_HID_DESCRIPTOR(ITF_NUM_HID_REL_M,
+                       STRID_MOUSE,
+                       HID_ITF_PROTOCOL_NONE,
+                       sizeof(desc_hid_report_relmouse),
+                       EPNUM_HID_REL_M,
+                       CFG_TUD_HID_EP_BUFSIZE,
+                       1),
+
+#if DFU_RT_ENABLED
+    // Interface number, string index, attributes, detach timeout, transfer size */
+    TUD_DFU_RT_DESCRIPTOR(ITF_NUM_DFU_RT,
+			  STRID_DFU_RUNTIME,
+			  DFU_ATTR_CAN_DOWNLOAD | DFU_ATTR_CAN_UPLOAD | DFU_ATTR_WILL_DETACH,
+			  DFU_MAX_WAIT,
+			  CFG_TUD_DFU_XFER_BUFSIZE),
+#endif
+
+#ifdef DH_DEBUG
+    // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC,
+		       STRID_DEBUG,
+		       EPNUM_CDC_NOTIF,
+		       8,
+		       EPNUM_CDC_OUT,
+		       EPNUM_CDC_IN,
+		       CFG_TUD_CDC_EP_BUFSIZE),
+#endif
+};
+
+//--------------------------------------------------------------------+
+// Callbacks
+//--------------------------------------------------------------------+
+
+//--------------------------------------------------------------------+
+// Helpers
+//--------------------------------------------------------------------+
+
+bool tud_mouse_report(uint8_t mode,
+                      uint8_t buttons,
+                      int16_t x,
+                      int16_t y,
+                      int8_t wheel) {
+
+    if (mode == ABSOLUTE) {
+        mouse_report_t report = {.buttons = buttons, .x = x, .y = y, .wheel = wheel};
+        return tud_hid_n_report(ITF_NUM_HID, REPORT_ID_MOUSE, &report, sizeof(report));
+    }
+    else {
+        hid_mouse_report_t report = {.buttons = buttons, .x = x - 16384, .y = y - 16384, .wheel = wheel, .pan = 0};
+        return tud_hid_n_report(ITF_NUM_HID_REL_M, REPORT_ID_RELMOUSE, &report, sizeof(report));
+    }
+}

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -91,7 +91,22 @@ hotkey_combo_t hotkeys[] = {
      .keys           = {HID_KEY_F12, HID_KEY_B},
      .key_count      = 2,
      .acknowledge    = true,
-     .action_handler = &fw_upgrade_hotkey_handler_B}};
+     .action_handler = &fw_upgrade_hotkey_handler_B},
+
+    /* Hold down left shift + right shift + F12 + C ==> DFU mode for board A (kbd) */
+    {.modifier       = KEYBOARD_MODIFIER_RIGHTSHIFT | KEYBOARD_MODIFIER_LEFTSHIFT,
+     .keys           = {HID_KEY_F12, HID_KEY_C},
+     .key_count      = 2,
+     .acknowledge    = true,
+     .action_handler = &dfu_hotkey_handler_A},
+
+    /* Hold down left shift + right shift + F12 + D ==> DFU mode for board B (mouse) */
+    {.modifier       = KEYBOARD_MODIFIER_RIGHTSHIFT | KEYBOARD_MODIFIER_LEFTSHIFT,
+     .keys           = {HID_KEY_F12, HID_KEY_D},
+     .key_count      = 2,
+     .acknowledge    = true,
+     .action_handler = &dfu_hotkey_handler_B},
+};
 
 /* ============================================================ *
  * Detect if any hotkeys were pressed

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@
 
 #include "main.h"
 
-/*********  Global Variable  **********/
+/*********  Global Variables  **********/
 device_t global_state = {0};
 device_t *device      = &global_state;
 

--- a/src/main.c
+++ b/src/main.c
@@ -32,21 +32,25 @@ int main(void) {
     // Initial board setup
     initial_setup(device);
 
-    // Initial state, A is the default output
-    switch_output(device, OUTPUT_A);
+    if (!device->dfu_mode) {
+	    // Initial state, A is the default output
+	    switch_output(device, OUTPUT_A);
+    }
 
     while (true) {
         // USB device task, needs to run as often as possible
         tud_task();
 
-        // Verify core1 is still running and if so, reset watchdog timer
-        kick_watchdog(device);
+	if (!device->dfu_mode) {
+		// Verify core1 is still running and if so, reset watchdog timer
+		kick_watchdog(device);
 
-        // Check if there were any keypresses and send them
-        process_kbd_queue_task(device);
+		// Check if there were any keypresses and send them
+		process_kbd_queue_task(device);
 
-        // Check if there were any mouse movements and send them
-        process_mouse_queue_task(device);
+		// Check if there were any mouse movements and send them
+		process_mouse_queue_task(device);
+	}
     }
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -318,6 +318,7 @@ bool verify_checksum(const uart_packet_t *);
 
 /*********  Watchdog  **********/
 void kick_watchdog(device_t *);
+void reboot_board(uint32_t mode);
 
 /*********  Configuration  **********/
 void load_config(device_t *);

--- a/src/main.h
+++ b/src/main.h
@@ -213,9 +213,6 @@ typedef struct {
 
 extern const config_t default_config;
 
-extern config_t ADDR_CONFIG[];
-#define ADDR_CONFIG_BASE_ADDR (ADDR_CONFIG)
-
 // -------------------------------------------------------+
 
 typedef void (*action_handler_t)();

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -104,10 +104,15 @@ extern int dh_debug_printf(const char *__restrict __format, ...);
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_HID    2
-#define CFG_TUD_MSC    0
-#define CFG_TUD_MIDI   0
-#define CFG_TUD_VENDOR 0
+#define CFG_TUD_HID		2
+#define CFG_TUD_MSC		0
+#define CFG_TUD_MIDI		0
+#define CFG_TUD_VENDOR		0
+#define CFG_TUD_DFU_RUNTIME	1
+#define CFG_TUD_DFU		1
+
+// DFU buffer size (using FLASH_SECTOR_SIZE simplifies download operations)
+#define CFG_TUD_DFU_XFER_BUFSIZE 4096
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
 #define CFG_TUD_HID_EP_BUFSIZE 32

--- a/src/uart.c
+++ b/src/uart.c
@@ -57,6 +57,7 @@ const uart_handler_t uart_handler[] = {
     {.type = SCREENSAVER_MSG, .handler = handle_screensaver_msg},
     {.type = WIPE_CONFIG_MSG, .handler = handle_wipe_config_msg},
     {.type = OUTPUT_CONFIG_MSG, .handler = handle_output_config_msg},
+    {.type = DFU_MSG, .handler = handle_dfu_msg},
 };
 
 void process_packet(uart_packet_t *packet, device_t *state) {

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -1,4 +1,21 @@
 /*
+ * This file is part of DeskHop (https://github.com/hrvach/deskhop).
+ * Copyright (c) 2024 Hrvoje Cavrak
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Ha Thach (tinyusb.org)
@@ -23,102 +40,42 @@
  *
  */
 
-#include "usb_descriptors.h"
 #include "main.h"
-#include "tusb.h"
+#include "usb_descriptors.h"
+#include <pico/unique_id.h>
+
+static char serial_str[PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2 + 1];
 
 //--------------------------------------------------------------------+
 // Device Descriptors
 //--------------------------------------------------------------------+
-tusb_desc_device_t const desc_device = {.bLength         = sizeof(tusb_desc_device_t),
-                                        .bDescriptorType = TUSB_DESC_DEVICE,
-                                        .bcdUSB          = 0x0200,
-                                        .bDeviceClass    = 0x00,
-                                        .bDeviceSubClass = 0x00,
-                                        .bDeviceProtocol = 0x00,
-                                        .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
-
-                                        // https://github.com/raspberrypi/usb-pid
-                                        .idVendor  = 0x2E8A,
-                                        .idProduct = 0x107C,
-                                        .bcdDevice = 0x0100,
-
-                                        .iManufacturer = 0x01,
-                                        .iProduct      = 0x02,
-                                        .iSerialNumber = 0x03,
-
-                                        .bNumConfigurations = 0x01};
 
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const *tud_descriptor_device_cb(void) {
-    return (uint8_t const *)&desc_device;
+	return (uint8_t const *) (global_state.dfu_mode ? &desc_device_dfu : &desc_device_hid);
 }
-
-//--------------------------------------------------------------------+
-// HID Report Descriptor
-//--------------------------------------------------------------------+
-
-// Relative mouse is used to overcome limitations of multiple desktops on MacOS and Windows
-
-uint8_t const desc_hid_report[] = {TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(REPORT_ID_KEYBOARD)),
-                                   TUD_HID_REPORT_DESC_ABSMOUSE(HID_REPORT_ID(REPORT_ID_MOUSE))};
-
-uint8_t const desc_hid_report_relmouse[] = {TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(REPORT_ID_RELMOUSE))};
-
-// Invoked when received GET HID REPORT DESCRIPTOR
-// Application return pointer to descriptor
-// Descriptor contents must exist long enough for transfer to complete
-uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance) {
-    if (instance == ITF_NUM_HID_REL_M) {
-        return desc_hid_report_relmouse;
-    }
-
-    /* Default */
-    return desc_hid_report;
-}
-
-bool tud_mouse_report(uint8_t mode,
-                      uint8_t buttons,
-                      int16_t x,
-                      int16_t y,
-                      int8_t wheel) {
-
-    if (mode == ABSOLUTE) {
-        mouse_report_t report = {.buttons = buttons, .x = x, .y = y, .wheel = wheel};
-        return tud_hid_n_report(ITF_NUM_HID, REPORT_ID_MOUSE, &report, sizeof(report));
-    }
-    else {
-        hid_mouse_report_t report = {.buttons = buttons, .x = x - 16384, .y = y - 16384, .wheel = wheel, .pan = 0};
-        return tud_hid_n_report(ITF_NUM_HID_REL_M, REPORT_ID_RELMOUSE, &report, sizeof(report));
-    }
-}
-
 
 //--------------------------------------------------------------------+
 // String Descriptors
 //--------------------------------------------------------------------+
 
 // array of pointer to string descriptors
+// must match the String Descriptor Index in usb_descriptors.h
 char const *string_desc_arr[] = {
-    (const char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
-    "Hrvoje Cavrak",            // 1: Manufacturer
-    "DeskHop Switch",           // 2: Product
-    "0",                        // 3: Serials, should use chip ID
-    "MouseHelper",              // 4: Relative mouse to work around OS issues
+    (const char[]){0x09, 0x04}, //  0: is supported language is English (0x0409)
+    "Hrvoje Cavrak",            //  1: Manufacturer
+    "DeskHop Switch",           //  2: Product
+    "",                         //  3: Serial, will use board unique ID (from flash chip)
+    "MouseHelper",              //  4: Relative mouse to work around OS issues
+    "DeskHop DFU",              //  5: DFU runtime
+    "board_a_fw",	        //  6: DFU - board A firmware
+    "board_b_fw",	        //  7: DFU - board B firmware
+    "config",		        //  8: DFU - configuration block
+    "dfu_buffer",               //  9: DFU - dfu buffer (debug mode only)
 #ifdef DH_DEBUG
-    "Debug Interface", // 5: Debug Interface
+    "Debug Interface",          // 10: Debug Interface
 #endif
-};
-
-// String Descriptor Index
-enum {
-    STRID_LANGID = 0,
-    STRID_MANUFACTURER,
-    STRID_PRODUCT,
-    STRID_SERIAL,
-    STRID_MOUSE,
-    STRID_DEBUG,
 };
 
 static uint16_t _desc_str[32];
@@ -131,17 +88,26 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 
     uint8_t chr_count;
 
-    if (index == 0) {
+    if (index == STRID_LANGID) {
         memcpy(&_desc_str[1], string_desc_arr[0], 2);
         chr_count = 1;
     } else {
         // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
-        if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0])))
+	if (!(index < count_of(string_desc_arr)))
             return NULL;
 
-        const char *str = string_desc_arr[index];
+	const char *str;
+
+	if (index == STRID_SERIAL) {
+	    if (!serial_str[0]) {
+	        pico_get_unique_board_id_string(serial_str, sizeof(serial_str));
+	    }
+	    str = serial_str;
+	} else {
+	    str = string_desc_arr[index];
+	}
 
         // Cap at max char
         chr_count = strlen(str);
@@ -164,55 +130,7 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 // Configuration Descriptor
 //--------------------------------------------------------------------+
 
-#define EPNUM_HID       0x81
-#define EPNUM_HID_REL_M 0x82
-
-#ifndef DH_DEBUG
-
-enum { ITF_NUM_TOTAL = 2 };
-#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_HID_DESC_LEN)
-
-#else
-
-enum { ITF_NUM_CDC = 2, ITF_NUM_TOTAL = 3 };
-#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_HID_DESC_LEN + TUD_CDC_DESC_LEN)
-#define EPNUM_CDC_NOTIF  0x83
-#define EPNUM_CDC_OUT    0x04
-#define EPNUM_CDC_IN     0x84
-
-#endif
-
-
-uint8_t const desc_configuration[] = {
-    // Config number, interface count, string index, total length, attribute, power in mA
-    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 500),
-
-    // Interface number, string index, protocol, report descriptor len, EP In address, size & polling interval
-    TUD_HID_DESCRIPTOR(ITF_NUM_HID,
-                       STRID_PRODUCT,
-                       HID_ITF_PROTOCOL_NONE,
-                       sizeof(desc_hid_report),
-                       EPNUM_HID,
-                       CFG_TUD_HID_EP_BUFSIZE,
-                       1),
-
-    TUD_HID_DESCRIPTOR(ITF_NUM_HID_REL_M,
-                       STRID_MOUSE,
-                       HID_ITF_PROTOCOL_NONE,
-                       sizeof(desc_hid_report_relmouse),
-                       EPNUM_HID_REL_M,
-                       CFG_TUD_HID_EP_BUFSIZE,
-                       1),
-
-#ifdef DH_DEBUG
-    // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
-    TUD_CDC_DESCRIPTOR(
-        ITF_NUM_CDC, STRID_DEBUG, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, CFG_TUD_CDC_EP_BUFSIZE),
-#endif
-
-};
-
 uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
     (void)index; // for multiple configurations
-    return desc_configuration;
+    return (global_state.dfu_mode ? desc_configuration_dfu : desc_configuration_hid);
 }

--- a/src/usb_descriptors.h
+++ b/src/usb_descriptors.h
@@ -1,29 +1,45 @@
-/* 
- * The MIT License (MIT)
+/*
+ * This file is part of DeskHop (https://github.com/hrvach/deskhop).
+ * Copyright (c) 2024 Hrvoje Cavrak
  *
- * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef USB_DESCRIPTORS_H_
 #define USB_DESCRIPTORS_H_
+
+extern tusb_desc_device_t const desc_device_hid;
+extern tusb_desc_device_t const desc_device_dfu;
+
+extern uint8_t const desc_configuration_hid[];
+extern uint8_t const desc_configuration_dfu[];
+
+// String Descriptor Index
+enum {
+    STRID_LANGID = 0,
+    STRID_MANUFACTURER,
+    STRID_PRODUCT,
+    STRID_SERIAL,
+    STRID_MOUSE,
+    STRID_DFU_RUNTIME,
+    STRID_DFU_BOARD_A_FW,
+    STRID_DFU_BOARD_B_FW,
+    STRID_DFU_CONFIG,
+    STRID_DFU_DFU_BUFFER,
+#ifdef DH_DEBUG
+    STRID_DEBUG,
+#endif
+};
 
 enum
 {

--- a/src/user_config.h
+++ b/src/user_config.h
@@ -172,3 +172,26 @@
  * */
 
 #define ENFORCE_PORTS 0
+
+/** ================================================== *
+ *  ================  DFU Config ===================== *
+ *  ================================================== *
+ *
+ * Support for USB DFU (Device Firmware Update), allowing
+ * the DeskHop firmware and configuration data to be copied
+ * to/from an attached computer without any need to restart
+ * the DeskHop into "USB Boot" mode.
+ *
+ **/
+
+/** ================================================== *
+ *
+ * DFU_RT_ENABLED: [0 or 1] 1 means the DFU functionality can
+ * be initiated over the USB output ports.
+ *
+ * This is disabled by default, since it adds a possible
+ * exposure channel to existing devices after upgrades.
+ *
+ **/
+
+#define DFU_RT_ENABLED 0

--- a/src/utils.c
+++ b/src/utils.c
@@ -56,6 +56,15 @@ void kick_watchdog(device_t *state) {
         watchdog_update();
 }
 
+void reboot_board(uint32_t mode) {
+    watchdog_hw->scratch[0] = mode;
+    watchdog_reboot(0x00000000, 0x00000000, 50);
+
+    /* Wait for the reset */
+    while(true)
+        tight_loop_contents();
+}
+
 /* ================================================== *
  * Flash and config functions
  * ================================================== */


### PR DESCRIPTION
Implementation of #77.

* Adds "DFU Runtime" support while the application is in "HID" (normal) mode; this is controllable in `user_config.h` and defaults to 'off'. This allows a DFU tool to trigger a reboot into "DFU" mode.

* Adds "DFU" mode for the application, which avoids most normal setup steps and prepares the device for firmware/config upload or download. The board still stay in this mode for a maximum of 30 seconds, and will reboot if no successful DFU operation occurs within that time.

* Adds serial number reporting using the Pico SDK "unique_id" function which obtains the hardware serial number from the flash chip.

* Refactors usb_descriptors.c into dfu.c and hid.c for clarity.

* Adds DFU 'upload' mode, allowing the user to obtain the current firmware or runtime configuration from the device.

* Adds DFU 'download' mode, allowing the user to flash new firmware or configuration to the device. The device will automatically reboot after the flash operation.

Since this is 'phase 1', it only supports DFU operations against the board it is attached to (A or B), it does not support operations against the 'other' board over a single connection. This means that upgrading firmware must be done twice, connecting to each board.