### PR TITLE
chore: fix screenlock

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -117,7 +117,7 @@ void screenlock_hotkey_handler(device_t *state, hid_keyboard_report_t *report) {
                 break;
         }
 
-        if (global_state.active_output == out) {
+        if (BOARD_ROLE == out) {
             queue_kbd_report(&lock_report, state);
             release_all_keys(state);
         } else {


### PR DESCRIPTION
Hi there, :wave: 

I noticed that the screenlock only worked, when the keyboard is connected to the active device. I did not work, when the other one was active. The reason for this, is that the shortcut is always received on the device the keyboard is connected to. So we should always send the command to all others.

Cheers,
Jan