### PR TITLE
Wake up on keyboard events

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -150,8 +150,13 @@ void process_kbd_queue_task(device_t *state) {
     if (!queue_try_peek(&state->kbd_queue, &report))
         return;
 
-    /* ... try sending it to the host, if it's successful */
-    bool succeeded = tud_hid_keyboard_report(REPORT_ID_KEYBOARD, report.modifier, report.keycode);
+    bool succeeded = false;
+
+    if (tud_suspended())
+        succeeded = tud_remote_wakeup();
+    else
+        /* ... try sending it to the host, if it's successful */
+        succeeded = tud_hid_keyboard_report(REPORT_ID_KEYBOARD, report.modifier, report.keycode);
 
     /* ... then we can remove it from the queue. Race conditions shouldn't happen [tm] */
     if (succeeded)


### PR DESCRIPTION
Keyboard events do not wake up host in the current implementation (only mouse movement does). This patch fixes that. 