### PR TITLE
Allow dragging between screens on same output

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -184,8 +184,8 @@ void check_screen_switch(const mouse_values_t *values, device_t *state) {
 
     int direction = jump_left ? LEFT : RIGHT;
 
-    /* No switching allowed if explicitly disabled or mouse button is held */
-    if (state->switch_lock || state->mouse_buttons)
+    /* No switching allowed if explicitly disabled */
+    if (state->switch_lock)
         return;
 
     /* No jump condition met == nothing to do, return */
@@ -194,9 +194,12 @@ void check_screen_switch(const mouse_values_t *values, device_t *state) {
 
     /* We want to jump in the direction of the other computer */
     if (output->pos != direction) {
-        if (output->screen_index == 1) /* We are at the border -> switch outputs */
-            switch_screen(state, output, new_x, state->active_output, 1 - state->active_output, direction);
-
+        if (output->screen_index == 1) { /* We are at the border -> switch outputs */
+            if (state->mouse_buttons) /* If mouse button is held, switching output is disallowed */
+                return;
+            else /* But we can switch screens on the same output if button is held */
+                switch_screen(state, output, new_x, state->active_output, 1 - state->active_output, direction);
+        }
         /* If here, this output has multiple desktops and we are not on the main one */
         else
             switch_desktop(state, output, output->screen_index - 1, direction);


### PR DESCRIPTION
First off, thanks for this project - I was slowly working out how to do this myself when I stumbled across it, executed much better than I suspect I could!

As-is, you are prevented from switching outputs when a mouse button is held (which usually means you're dragging something). That makes sense, but you should (I believe?) be able to drag between screens on the same output; I've attempted to allow that in this PR, and it seems to be working for my purposes.

However, there are definitely some aspects I don't understand here, particularly around the various quirks on different operating systems, so happy to iterate until I do and this, or some variant of it, can be accepted. The main thing that was mysterious was that even with no modifications, I was able to drag from my secondary screen to my primary screen - I was just unable to drag from my primary screen to my secondary screen. I suspect (though it's a total guess on my part) that's something to do with the difference between desktops and screens (which I have not understood yet), but the inconsistency suggests to me something is amiss somewhere!