### PR TITLE
Unbreak relative mouse mode by adding pan to descriptor

### DIFF
--- a/src/include/usb_descriptors.h
+++ b/src/include/usb_descriptors.h
@@ -198,6 +198,15 @@ HID_COLLECTION_END \
         HID_REPORT_COUNT( 1                                      )  ,\
         HID_REPORT_SIZE ( 8                                      )  ,\
         HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE )  ,\
+        /* Horizontal wheel (AC Pan) */ \
+        HID_USAGE_PAGE  ( HID_USAGE_PAGE_CONSUMER               )   ,\
+        HID_LOGICAL_MIN ( 0x81                                   )   ,\
+        HID_LOGICAL_MAX ( 0x7f                                   )   ,\
+        HID_REPORT_COUNT( 1                                      )   ,\
+        HID_REPORT_SIZE ( 8                                      )   ,\
+        HID_USAGE_N     ( HID_USAGE_CONSUMER_AC_PAN, 2          )   ,\
+        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE )  ,\
+        \
         /* Mouse mode (0 = absolute, 1 = relative) */ \
         HID_REPORT_COUNT( 1                                      ), \
         HID_REPORT_SIZE ( 8                                      ), \

--- a/src/include/usb_descriptors.h
+++ b/src/include/usb_descriptors.h
@@ -55,64 +55,70 @@
   .iSerialNumber = 0x03,\
   .bNumConfigurations = 0x01}\
 
+/* Common mouse descriptor. Use HID_RELATIVE or HID_ABSOLUTE for ABS_OR_REL. */
+#define TUD_HID_REPORT_DESC_MOUSE_COMMON(ABS_OR_REL, MOUSE_MIN, ...)\
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP      )                   ,\
+  HID_USAGE      ( HID_USAGE_DESKTOP_MOUSE     )                   ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION  )                   ,\
+    /* Report ID if any */\
+    __VA_ARGS__ \
+    HID_USAGE      ( HID_USAGE_DESKTOP_POINTER )                   ,\
+    HID_COLLECTION ( HID_COLLECTION_PHYSICAL   )                   ,\
+      HID_USAGE_PAGE  ( HID_USAGE_PAGE_BUTTON  )                   ,\
+        HID_USAGE_MIN   ( 1                                      ) ,\
+        HID_USAGE_MAX   ( 5                                      ) ,\
+        HID_LOGICAL_MIN ( 0                                      ) ,\
+        HID_LOGICAL_MAX ( 1                                      ) ,\
+        \
+        /* Left, Right, Middle, Backward, Forward buttons */ \
+        HID_REPORT_COUNT( 5                                      ) ,\
+        HID_REPORT_SIZE ( 1                                      ) ,\
+        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+        \
+        /* 3 bit padding */ \
+        HID_REPORT_COUNT( 1                                      ) ,\
+        HID_REPORT_SIZE ( 3                                      ) ,\
+        HID_INPUT       ( HID_CONSTANT                           ) ,\
+      HID_USAGE_PAGE  ( HID_USAGE_PAGE_DESKTOP )                   ,\
+        \
+        /* X, Y position [MOUSE_MIN, 32767] */ \
+        HID_USAGE       ( HID_USAGE_DESKTOP_X                    ) ,\
+        HID_USAGE       ( HID_USAGE_DESKTOP_Y                    ) ,\
+        MOUSE_MIN                                                  ,\
+        HID_LOGICAL_MAX_N( 0x7FFF, 2                             ) ,\
+        HID_REPORT_SIZE  ( 16                                    ) ,\
+        HID_REPORT_COUNT ( 2                                     ) ,\
+        HID_INPUT       ( HID_DATA | HID_VARIABLE | ABS_OR_REL   ) ,\
+        \
+        /* Vertical wheel scroll [-127, 127] */ \
+        HID_USAGE       ( HID_USAGE_DESKTOP_WHEEL                ) ,\
+        HID_LOGICAL_MIN ( 0x81                                   ) ,\
+        HID_LOGICAL_MAX ( 0x7f                                   ) ,\
+        HID_REPORT_COUNT( 1                                      ) ,\
+        HID_REPORT_SIZE ( 8                                      ) ,\
+        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE ) ,\
+        \
+        /* Horizontal wheel (AC Pan) */ \
+        HID_USAGE_PAGE  ( HID_USAGE_PAGE_CONSUMER                ) ,\
+        HID_LOGICAL_MIN ( 0x81                                   ) ,\
+        HID_LOGICAL_MAX ( 0x7f                                   ) ,\
+        HID_REPORT_COUNT( 1                                      ) ,\
+        HID_REPORT_SIZE ( 8                                      ) ,\
+        HID_USAGE_N     ( HID_USAGE_CONSUMER_AC_PAN, 2           ) ,\
+        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE ) ,\
+        \
+        /* Mouse mode (0 = absolute, 1 = relative) */ \
+        HID_REPORT_COUNT( 1                                      ), \
+        HID_REPORT_SIZE ( 8                                      ), \
+        HID_INPUT       ( HID_CONSTANT                           ), \
+    HID_COLLECTION_END                                            , \
+  HID_COLLECTION_END \
 
-#define TUD_HID_REPORT_DESC_ABS_MOUSE(...) \
-HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP      )                   ,\
-HID_USAGE      ( HID_USAGE_DESKTOP_MOUSE     )                   ,\
-HID_COLLECTION ( HID_COLLECTION_APPLICATION  )                   ,\
-  /* Report ID */\
-  __VA_ARGS__ \
-  HID_USAGE      ( HID_USAGE_DESKTOP_POINTER )                   ,\
-  HID_COLLECTION ( HID_COLLECTION_PHYSICAL   )                   ,\
-    HID_USAGE_PAGE  ( HID_USAGE_PAGE_BUTTON  )                   ,\
-      HID_USAGE_MIN   ( 1                                      ) ,\
-      HID_USAGE_MAX   ( 5                                      ) ,\
-      HID_LOGICAL_MIN ( 0                                      ) ,\
-      HID_LOGICAL_MAX ( 1                                      ) ,\
-      \
-      /* Left, Right, Middle, Backward, Forward buttons */ \
-      HID_REPORT_COUNT( 5                                      ) ,\
-      HID_REPORT_SIZE ( 1                                      ) ,\
-      HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-      \
-      /* 3 bit padding */ \
-      HID_REPORT_COUNT( 1                                      ) ,\
-      HID_REPORT_SIZE ( 3                                      ) ,\
-      HID_INPUT       ( HID_CONSTANT                           ) ,\
-    HID_USAGE_PAGE  ( HID_USAGE_PAGE_DESKTOP )                   ,\
-      \
-      /* X, Y absolute position [0, 32767] */ \
-      HID_USAGE       ( HID_USAGE_DESKTOP_X                    ) ,\
-      HID_USAGE       ( HID_USAGE_DESKTOP_Y                    ) ,\
-      HID_LOGICAL_MIN  ( 0x00                                ) ,\
-      HID_LOGICAL_MAX_N( 0x7FFF, 2                           ) ,\
-      HID_REPORT_SIZE  ( 16                                  ) ,\
-      HID_REPORT_COUNT ( 2                                   ) ,\
-      HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-      \
-      /* Vertical wheel scroll [-127, 127] */ \
-      HID_USAGE       ( HID_USAGE_DESKTOP_WHEEL                )  ,\
-      HID_LOGICAL_MIN ( 0x81                                   )  ,\
-      HID_LOGICAL_MAX ( 0x7f                                   )  ,\
-      HID_REPORT_COUNT( 1                                      )  ,\
-      HID_REPORT_SIZE ( 8                                      )  ,\
-      HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE )  ,\
-      \
-      /* Horizontal wheel (AC Pan) */ \
-      HID_USAGE_PAGE  ( HID_USAGE_PAGE_CONSUMER               )   ,\
-      HID_LOGICAL_MIN ( 0x81                                   )   ,\
-      HID_LOGICAL_MAX ( 0x7f                                   )   ,\
-      HID_REPORT_COUNT( 1                                      )   ,\
-      HID_REPORT_SIZE ( 8                                      )   ,\
-      HID_USAGE_N     ( HID_USAGE_CONSUMER_AC_PAN, 2          )   ,\
-      HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE )  ,\
-      \
-      /* Mouse mode (0 = absolute, 1 = relative) */ \
-      HID_REPORT_COUNT( 1                                      ), \
-      HID_REPORT_SIZE ( 8                                      ), \
-      HID_INPUT       ( HID_CONSTANT                           ), \
-  HID_COLLECTION_END                                            , \
-HID_COLLECTION_END \
+/* Absolute mouse, range=[0..32767] */
+#define TUD_HID_REPORT_DESC_ABS_MOUSE(...) TUD_HID_REPORT_DESC_MOUSE_COMMON(HID_ABSOLUTE, HID_LOGICAL_MIN(0), __VA_ARGS__)
+
+/* Relative mouse, range=[-32767..32767] */
+#define TUD_HID_REPORT_DESC_MOUSEHELP(...) TUD_HID_REPORT_DESC_MOUSE_COMMON(HID_RELATIVE, HID_LOGICAL_MIN_N(-32767, 2), __VA_ARGS__)
 
 // Consumer Control Report Descriptor Template
 #define TUD_HID_REPORT_DESC_CONSUMER_CTRL(...) \
@@ -159,59 +165,6 @@ HID_COLLECTION_END \
     HID_INPUT        ( HID_DATA | HID_ARRAY | HID_ABSOLUTE ) ,\
     HID_USAGE       ( 0x10                                )  ,\
     HID_OUTPUT       ( HID_DATA | HID_ARRAY | HID_ABSOLUTE ) ,\
-  HID_COLLECTION_END \
-
-#define TUD_HID_REPORT_DESC_MOUSEHELP(...) \
-  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP      )                   ,\
-  HID_USAGE      ( HID_USAGE_DESKTOP_MOUSE     )                   ,\
-  HID_COLLECTION ( HID_COLLECTION_APPLICATION  )                   ,\
-    /* Report ID if any */\
-    __VA_ARGS__ \
-    HID_USAGE      ( HID_USAGE_DESKTOP_POINTER )                   ,\
-    HID_COLLECTION ( HID_COLLECTION_PHYSICAL   )                   ,\
-      HID_USAGE_PAGE  ( HID_USAGE_PAGE_BUTTON  )                   ,\
-        HID_USAGE_MIN   ( 1                                      ) ,\
-        HID_USAGE_MAX   ( 5                                      ) ,\
-        HID_LOGICAL_MIN ( 0                                      ) ,\
-        HID_LOGICAL_MAX ( 1                                      ) ,\
-        /* Left, Right, Middle, Backward, Forward buttons */ \
-        HID_REPORT_COUNT( 5                                      ) ,\
-        HID_REPORT_SIZE ( 1                                      ) ,\
-        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-        /* 3 bit padding */ \
-        HID_REPORT_COUNT( 1                                      ) ,\
-        HID_REPORT_SIZE ( 3                                      ) ,\
-        HID_INPUT       ( HID_CONSTANT                           ) ,\
-      HID_USAGE_PAGE  ( HID_USAGE_PAGE_DESKTOP )                   ,\
-        /* X, Y position [-32767, 32767] */ \
-        HID_USAGE       ( HID_USAGE_DESKTOP_X                    ) ,\
-        HID_USAGE       ( HID_USAGE_DESKTOP_Y                    ) ,\
-        HID_LOGICAL_MIN_N ( 0x8000, 2                            ) ,\
-        HID_LOGICAL_MAX_N ( 0x7fff, 2                            ) ,\
-        HID_REPORT_SIZE ( 16                                     ) ,\
-        HID_REPORT_COUNT( 2                                      ) ,\
-        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE ) ,\
-        /* Vertical wheel scroll [-127, 127] */ \
-        HID_USAGE       ( HID_USAGE_DESKTOP_WHEEL                )  ,\
-        HID_LOGICAL_MIN ( 0x81                                   )  ,\
-        HID_LOGICAL_MAX ( 0x7f                                   )  ,\
-        HID_REPORT_COUNT( 1                                      )  ,\
-        HID_REPORT_SIZE ( 8                                      )  ,\
-        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE )  ,\
-        /* Horizontal wheel (AC Pan) */ \
-        HID_USAGE_PAGE  ( HID_USAGE_PAGE_CONSUMER               )   ,\
-        HID_LOGICAL_MIN ( 0x81                                   )   ,\
-        HID_LOGICAL_MAX ( 0x7f                                   )   ,\
-        HID_REPORT_COUNT( 1                                      )   ,\
-        HID_REPORT_SIZE ( 8                                      )   ,\
-        HID_USAGE_N     ( HID_USAGE_CONSUMER_AC_PAN, 2          )   ,\
-        HID_INPUT       ( HID_DATA | HID_VARIABLE | HID_RELATIVE )  ,\
-        \
-        /* Mouse mode (0 = absolute, 1 = relative) */ \
-        HID_REPORT_COUNT( 1                                      ), \
-        HID_REPORT_SIZE ( 8                                      ), \
-        HID_INPUT       ( HID_CONSTANT                           ), \
-    HID_COLLECTION_END                                            , \
   HID_COLLECTION_END \
 
 #define HID_USAGE_DIGITIZER 0x01

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -81,10 +81,10 @@ uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance) {
     }
 }
 
-    uint8_t instance = ITF_NUM_HID;
-    uint8_t report_id = REPORT_ID_MOUSE;
 bool tud_mouse_report(uint8_t mode, uint8_t buttons, int16_t x, int16_t y, int8_t wheel, int8_t pan) {
     mouse_report_t report = {.buttons = buttons, .wheel = wheel, .x = x, .y = y, .mode = mode, .pan = pan};
+    uint8_t instance = ITF_NUM_HID;
+    uint8_t report_id = REPORT_ID_MOUSE;
 
     if (mode == RELATIVE) {
         instance = ITF_NUM_HID_REL_M;


### PR DESCRIPTION
`tud_mouse_report()` sets `pan` for both absolute and relative reports but it hadn't been added to the relative mouse descriptor. This led to the host ignoring the relative reports because they didn't match the descriptor.

Additionally, moved the `instance` and `report_id` variables back into the function so it doesn't get stuck in relative mode after you send a single relative mouse report.