### PR TITLE
Tweak macos screen switch helper

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -140,9 +140,6 @@ void switch_screen(
     state->pointer_y = scale_y_coordinate(output->number, 1 - output->number, state);
 }
 
-#define MACOS_SWITCH_MOVE_X 10
-#define MACOS_SWITCH_MOVE_COUNT 5
-
 void switch_desktop_macos(device_t *state, int direction) {
     /* Fix for MACOS: Send relative mouse movement here, one or two pixels in the
        direction of movement, BEFORE absolute report sets X to 0 */


### PR DESCRIPTION
There seems to be a minimum amount of movement needed to convince Mac OS to switch the active screen. Moving 25/65536 units is less than one screen pixel at 1440p and below. Doubling that to 50 (5 * 10 units) is more than one screen pixel all the way down to 720p, and seems to be sufficient on both of my macbooks.

I also refactored the macos-specific desktop switch helper to its own function to make it a little clearer what is going on, and cleaned up some unused parameters in the main desktop switch function.