### PR TITLE
Add docker build method and update readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+
+# Set non-interactive mode for apt-get
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y sudo cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential python3 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /project
+
+CMD ["bash", "-c", "cmake -S . -B build && cmake --build build"]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ cmake -S . -B build
 cmake --build build
 ```
 
+Alternatively, you may use Docker to build by simply running:
+```
+docker compose run --rm build_container
+```
+
 additionally, to rebuild web UI check webconfig/ and execute ```./render.py```, you'll need jinja2 installed.
 
 To rebuild the disk, check disk/ folder and run ```./create.sh```, tweak to your system if needed. You'll need **dosfstools** (to provide mkdosfs),   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  build_container:
+    image: deskhop-build-env
+    build:
+      context: .
+    volumes:
+      - .:/project


### PR DESCRIPTION
This PR adds the ability to build the firmware by simply running:
```
docker compose run --rm build_container
```

The goal is to include a guaranteed reproducible build environment with minimal effort and cognitive load.