### PR TITLE
Improve HID report parsing and safety checks

### DIFF
--- a/src/hid_parser.c
+++ b/src/hid_parser.c
@@ -68,8 +68,11 @@ void store_element(parser_state_t *parser, report_val_t *val, int i, uint32_t da
 }
 
 void handle_global_item(parser_state_t *parser, item_t *item) {
-    if (item->hdr.tag == RI_GLOBAL_REPORT_ID)
+    if (item->hdr.tag == RI_GLOBAL_REPORT_ID) {
+        // reset offset for a new page
+        parser->offset_in_bits = 0;
         parser->report_id = item->val;
+    }
 
     parser->globals[item->hdr.tag] = *item;
 }

--- a/src/hid_report.c
+++ b/src/hid_report.c
@@ -19,7 +19,7 @@
 #include "main.h"
 
 /* Given a value struct with size and offset in bits, find and return a value from the HID report */
-int32_t get_report_value(uint8_t *report, report_val_t *val) {
+int32_t get_report_value(uint8_t *report, int len, report_val_t *val) {
     /* Calculate the bit offset within the byte */
     uint16_t offset_in_bits = val->offset % 8;
 
@@ -28,6 +28,9 @@ int32_t get_report_value(uint8_t *report, report_val_t *val) {
 
     /* Calculate the byte offset in the array */
     uint16_t byte_offset = val->offset >> 3;
+    
+    if (byte_offset >= len)
+        return 0;
 
     /* Create a mask for the specified number of bits */
     uint32_t mask = (1u << val->size) - 1;

--- a/src/include/main.h
+++ b/src/include/main.h
@@ -472,7 +472,7 @@ bool tud_mouse_report(uint8_t mode, uint8_t buttons, int16_t x, int16_t y, int8_
 void process_mouse_report(uint8_t *, int, uint8_t, hid_interface_t *);
 void parse_report_descriptor(hid_interface_t *, uint8_t const *, int);
 void extract_data(hid_interface_t *, report_val_t *);
-int32_t get_report_value(uint8_t *report, report_val_t *val);
+int32_t get_report_value(uint8_t *report, int len, report_val_t *val);
 void queue_mouse_report(mouse_report_t *, device_t *);
 void output_mouse_report(mouse_report_t *, device_t *);
 


### PR DESCRIPTION
Fix for #218 and possibly #133
- Add report length validation in get_report_value()
- Enhance report ID handling in extract_report_values()
- Reset bit offset when changing report ID in parser
- Add bounds checking to prevent potential buffer overruns