### PR TITLE
Enables support for multiple keyboard devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+
+.idea/

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -150,7 +150,17 @@ void config_enable_hotkey_handler(device_t *state, hid_keyboard_report_t *report
 
 /* Function handles received keypresses from the other board */
 void handle_keyboard_uart_msg(uart_packet_t *packet, device_t *state) {
-    queue_kbd_report((hid_keyboard_report_t *)packet->data, state);
+    hid_keyboard_report_t *report = (hid_keyboard_report_t *)packet->data;
+
+    /* Update the keyboard state for the remote device (using MAX_DEVICES-1 as the index) */
+    update_kbd_state(state, report, MAX_DEVICES-1);
+
+    /* Create a combined report from all device states */
+    hid_keyboard_report_t combined_report;
+    combine_kbd_states(state, &combined_report);
+
+    /* Queue the combined report */
+    queue_kbd_report(&combined_report, state);
     state->last_activity[BOARD_ROLE] = time_us_64();
 }
 

--- a/src/include/keyboard.h
+++ b/src/include/keyboard.h
@@ -28,6 +28,12 @@ int32_t  extract_kbd_data(uint8_t *, int, uint8_t, hid_interface_t *, hid_keyboa
 bool check_specific_hotkey(hotkey_combo_t, const hid_keyboard_report_t *);
 
 /*==============================================================================
+ *  Keyboard State Management
+ *==============================================================================*/
+void     update_kbd_state(device_t *, hid_keyboard_report_t *, uint8_t);
+void     combine_kbd_states(device_t *, hid_keyboard_report_t *);
+
+/*==============================================================================
  *  Keyboard Report Processing
  *==============================================================================*/
 bool     key_in_report(uint8_t, const hid_keyboard_report_t *);

--- a/src/include/structs.h
+++ b/src/include/structs.h
@@ -100,6 +100,10 @@ typedef struct {
     uint8_t active_output;               // Currently selected output (0 = A, 1 = B)
     uint8_t board_role;                  // Which board are we running on? (0 = A, 1 = B, etc.)
 
+    // Track keyboard state for each device
+    hid_keyboard_report_t kbd_states[MAX_DEVICES]; // Store keyboard state for each device
+    uint8_t kbd_device_count;                      // Number of active keyboard devices
+
     int16_t pointer_x; // Store and update the location of our mouse pointer
     int16_t pointer_y;
     int16_t mouse_buttons; // Store and update the state of mouse buttons

--- a/src/setup.c
+++ b/src/setup.c
@@ -231,6 +231,10 @@ void initial_setup(device_t *state) {
     queue_init(&state->kbd_queue, sizeof(hid_keyboard_report_t), KBD_QUEUE_LENGTH);
     queue_init(&state->mouse_queue, sizeof(mouse_report_t), MOUSE_QUEUE_LENGTH);
 
+    /* Initialize keyboard states for all devices */
+    memset(state->kbd_states, 0, sizeof(state->kbd_states));
+    state->kbd_device_count = 0;
+
     /* Initialize generic HID packet queue */
     queue_init(&state->hid_queue_out, sizeof(hid_generic_pkt_t), HID_QUEUE_LENGTH);
 


### PR DESCRIPTION
Adds support for combining keyboard input from multiple USB HID devices and a remote UART device.

This ensures all key presses are captured and sent, regardless of the input source.  It also resolves potential issues when switching between keyboards. This is achieved by storing the keyboard state for each device and merging these states into a combined report before sending.

This makes it possible, for example, to have with a Razer Naga (or any other mouse with side buttons) that its key does not overwrite the key state of the keyboard, as in an FPS, hold the key to move forward and press the "8" of the mouse without interruption.

My C++ is far away so do not hesitate to tell me things to optimize or in my way of doing things 😬