### PR TITLE
Add keyboard shortcut to enable the Jitter screensaver

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -115,13 +115,24 @@ void mouse_zoom_hotkey_handler(device_t *state, hid_keyboard_report_t *report) {
     send_value(state->mouse_zoom, MOUSE_ZOOM_MSG);
 };
 
-/* When pressed, enables the screensaver on active output */
-void enable_screensaver_hotkey_handler(device_t *state, hid_keyboard_report_t *report) {
+/* When pressed, enables the pong screensaver on active output */
+void enable_screensaver_pong_hotkey_handler(device_t *state, hid_keyboard_report_t *report) {
     uint8_t desired_mode = state->config.output[BOARD_ROLE].screensaver.mode;
 
-    /* If the user explicitly asks for screensaver to be active, ignore config and turn it on */
-    if (desired_mode == DISABLED)
+    /* If the user explicitly asks for pong screensaver to be active, ignore config and turn it on */
+    if (desired_mode == DISABLED || desired_mode == JITTER)
         desired_mode = PONG;
+
+    _screensaver_set(state, desired_mode);
+}
+
+/* When pressed, enables the jitter screensaver on active output */
+void enable_screensaver_jitter_hotkey_handler(device_t *state, hid_keyboard_report_t *report) {
+    uint8_t desired_mode = state->config.output[BOARD_ROLE].screensaver.mode;
+
+    /* If the user explicitly asks for jitter screensaver to be active, ignore config and turn it on */
+    if (desired_mode == DISABLED || desired_mode == PONG)
+        desired_mode = JITTER;
 
     _screensaver_set(state, desired_mode);
 }

--- a/src/include/handlers.h
+++ b/src/include/handlers.h
@@ -20,7 +20,8 @@
 
 void config_enable_hotkey_handler(device_t *, hid_keyboard_report_t *);
 void disable_screensaver_hotkey_handler(device_t *, hid_keyboard_report_t *);
-void enable_screensaver_hotkey_handler(device_t *, hid_keyboard_report_t *);
+void enable_screensaver_pong_hotkey_handler(device_t *, hid_keyboard_report_t *);
+void enable_screensaver_jitter_hotkey_handler(device_t *, hid_keyboard_report_t *);
 void fw_upgrade_hotkey_handler_A(device_t *, hid_keyboard_report_t *);
 void fw_upgrade_hotkey_handler_B(device_t *, hid_keyboard_report_t *);
 void mouse_zoom_hotkey_handler(device_t *, hid_keyboard_report_t *);

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -52,12 +52,19 @@ hotkey_combo_t hotkeys[] = {
      .acknowledge    = true,
      .action_handler = &toggle_gaming_mode_handler},
 
-    /* Enable screensaver for active output */
+    /* Enable screensaver pong for active output */
     {.modifier       = KEYBOARD_MODIFIER_LEFTCTRL | KEYBOARD_MODIFIER_RIGHTSHIFT,
      .keys           = {HID_KEY_S},
      .key_count      = 1,
      .acknowledge    = true,
-     .action_handler = &enable_screensaver_hotkey_handler},
+     .action_handler = &enable_screensaver_pong_hotkey_handler},
+
+    /* Enable screensaver jitter for active output */
+    {.modifier       = KEYBOARD_MODIFIER_LEFTCTRL | KEYBOARD_MODIFIER_RIGHTSHIFT,
+     .keys           = {HID_KEY_J},
+     .key_count      = 1,
+     .acknowledge    = true,
+     .action_handler = &enable_screensaver_jitter_hotkey_handler},
 
     /* Disable screensaver for active output */
     {.modifier       = KEYBOARD_MODIFIER_LEFTCTRL | KEYBOARD_MODIFIER_RIGHTSHIFT,


### PR DESCRIPTION
Disclaimer:  I've never done a pull request before, so feel free to reject this for any reason.

After I opened #272, I took a look at the keyboard handler code.  I found that the enable screensaver hotkey was hard coded to enable the pong screensaver.  It looked like the keyboard handlers referred to the state but not the configuration, so it wouldn't make any sense to update the existing enable screensaver handler to read the selected screensaver from the configuration.  I added another keyboard shortcut for left control + right shift + J to specially enable the Jitter screensaver instead.