### PR TITLE
Track HID report offsets per report ID

### DIFF
--- a/src/include/hid_parser.h
+++ b/src/include/hid_parser.h
@@ -38,6 +38,12 @@ typedef struct {
     uint8_t end;
 } collection_t;
 
+/* Maps a report ID to its current bit offset */
+typedef struct {
+    uint8_t report_id;
+    uint32_t offset_in_bits;
+} report_offset_map_t;
+
 /* Header byte is unpacked to size/type/tag using this struct */
 typedef struct TU_ATTR_PACKED {
     uint8_t size : 2;
@@ -149,12 +155,14 @@ typedef struct {
     int report_id; /* Report ID of the current section we're parsing */
 
     uint32_t usage_count;
-    uint32_t offset_in_bits;
     uint16_t usages[HID_MAX_USAGES];
     uint16_t *p_usage;
     uint16_t global_usage;
 
     collection_t collection;
+
+    report_offset_map_t report_offsets[MAX_REPORTS];
+    uint8_t num_report_offsets;
 
     /* as tag is 4 bits, there can be 16 different tags in global header type */
     item_t globals[16];


### PR DESCRIPTION
Based on my reading of the USB HID spec, each report ID defines an independent report structure with its own bit offset tracking. Previously, offsets were reset when encountering a new report ID or at collection boundaries, causing incorrect parsing of descriptors when the report ID swapped back and forth within the same descriptor.

Changes:
- Add report_offset_map_t to map report IDs to their offsets
- Track offsets separately for each report ID in parser state