### PR TITLE
Fix incorrect HID keyboard report parsing when Report IDs are used

### DIFF
--- a/src/hid_report.c
+++ b/src/hid_report.c
@@ -323,7 +323,7 @@ int32_t extract_kbd_data(
         return _extract_kbd_nkro(raw_report, len, iface, report);
 
     /* If we're getting 8 bytes of report, it's safe to assume standard modifier + reserved + keys */
-    if (len == KBD_REPORT_LENGTH || len == KBD_REPORT_LENGTH + 1)
+    if (!iface->uses_report_id && (len == KBD_REPORT_LENGTH || len == KBD_REPORT_LENGTH + 1))
         return _extract_kbd_boot(raw_report, len, report);
 
     /* This is something completely different, look at the report  */


### PR DESCRIPTION
The parser was incorrectly assuming that any 8-byte or 9-byte report was a
standard Boot Protocol report (Modifier, Reserved, 6 Keys). This caused
issues for devices like the Microsoft Ergonomic Keyboard that use Report IDs,
as the 1-byte Report ID was being misinterpreted as the Modifier byte.

Modified extract_kbd_data to only apply the Boot Protocol heuristic if the
interface is confirmed not to use Report IDs.
