### PR TITLE
fix: use offsetof for config checksum CRC range

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -79,7 +79,7 @@ void load_config(device_t *state) {
     memcpy(running_config, config, sizeof(config_t));
 
     /* Calculate and update checksum, size without checksum */
-    uint8_t checksum = calc_crc32((uint8_t *)running_config, sizeof(config_t) - sizeof(uint32_t));
+    uint8_t checksum = calc_crc32((uint8_t *)running_config, offsetof(config_t, checksum));
 
     /* We expect a certain byte to start the config header */
     bool magic_header_fail = (running_config->magic_header != 0xB00B1E5);
@@ -99,7 +99,7 @@ void save_config(device_t *state) {
     uint8_t *raw_config = (uint8_t *)&state->config;
 
     /* Calculate and update checksum, size without checksum */
-    uint8_t checksum       = calc_crc32(raw_config, sizeof(config_t) - sizeof(uint32_t));
+    uint8_t checksum       = calc_crc32(raw_config, offsetof(config_t, checksum));
     state->config.checksum = checksum;
 
     /* Copy the config to buffer and pad the rest with zeros */


### PR DESCRIPTION
## Summary

- Use `offsetof(config_t, checksum)` instead of `sizeof(config_t) - sizeof(uint32_t)` to compute the CRC range in `load_config()` and `save_config()`

## Problem

`sizeof(config_t) - sizeof(uint32_t)` assumes `checksum` occupies the last 4 bytes of the struct with no trailing padding. This holds **today** on ARM Cortex-M0+ because the current `config_t` layout happens to have 4-byte alignment.

However, `screensaver_t` contains `uint64_t` fields (`idle_time_us`, `max_time_us`), which give `output_t` an 8-byte alignment requirement on some ABIs. If `config_t` is extended with fields that break the current alignment (e.g., adding `uint8_t` fields before `checksum`), the compiler inserts **tail padding** after `checksum`, making `sizeof(config_t) - 4 > offsetof(config_t, checksum)`.

When this happens, the CRC range includes the `checksum` field itself (and padding bytes), causing `load_config()` to always fail validation and silently reset config to defaults on every boot — even after a successful `save_config()`.

## Fix

Replace `sizeof(config_t) - sizeof(uint32_t)` with `offsetof(config_t, checksum)`, which always computes the exact byte range before the checksum field regardless of struct padding.

## Testing

Verified on RP2040 hardware (DeskHop PCB v1.1):
- `save_config()` → flash verify OK → simulated `load_config()` CRC matches
- Config persists across reboots

## Test plan

- [x] Firmware builds without warnings on `arm-none-eabi-gcc`
- [x] Config save/load verified on hardware
- [x] No functional change for current upstream `config_t` layout (offsetof == sizeof - 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)