### PR TITLE
usb_descriptors: fix CDC interface numbers and total count in debug build

### DIFF
--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -176,9 +176,13 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 #define CONFIG_TOTAL_LEN_CFG (TUD_CONFIG_DESC_LEN + 3 * TUD_HID_DESC_LEN + TUD_MSC_DESC_LEN)
 
 #else
-#define ITF_NUM_CDC 4
-#define ITF_NUM_TOTAL 3
-#define ITF_NUM_TOTAL_CONFIG 5
+/* CDC uses 2 interfaces (control + data). In normal mode, place it right after
+   the 2 HID interfaces (at 2, 3). In config mode, place it after HID_VENDOR (2)
+   and MSC (3), so at 4, 5. */
+#define ITF_NUM_CDC 2
+#define ITF_NUM_CDC_CONFIG 4
+#define ITF_NUM_TOTAL 4
+#define ITF_NUM_TOTAL_CONFIG 6
 
 #define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + 2 * TUD_HID_DESC_LEN + TUD_CDC_DESC_LEN)
 #define CONFIG_TOTAL_LEN_CFG (TUD_CONFIG_DESC_LEN + 3 * TUD_HID_DESC_LEN + TUD_MSC_DESC_LEN + TUD_CDC_DESC_LEN)
@@ -254,7 +258,7 @@ uint8_t const desc_configuration_config[] = {
 #ifdef DH_DEBUG
     // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
     TUD_CDC_DESCRIPTOR(
-        ITF_NUM_CDC, STRID_DEBUG, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, CFG_TUD_CDC_EP_BUFSIZE),
+        ITF_NUM_CDC_CONFIG, STRID_DEBUG, EPNUM_CDC_NOTIF, 8, EPNUM_CDC_OUT, EPNUM_CDC_IN, CFG_TUD_CDC_EP_BUFSIZE),
 #endif
 };
 


### PR DESCRIPTION
## Summary
When DeskHop is built with `DH_DEBUG=ON`, the configuration descriptor declares CDC at interface number 4 with a total interface count of 3 (normal mode) or 5 (config mode). Both values are inconsistent with the actual descriptor contents:

| Mode | Actual interfaces | Declared `bNumInterfaces` |
|------|-------------------|---------------------------|
| Normal | HID(0), HID_REL_M(1), CDC ctrl(4), CDC data(5) → 4 | 3 |
| Config | HID(0), HID_REL_M(1), HID_VENDOR(2), MSC(3), CDC ctrl(4), CDC data(5) → 6 | 5 |

The non-consecutive interface numbers in normal mode (gaps at 2, 3) caused Windows to reject the device with **`CM_PROB_FAILED_START`** (problem code 10). Linux and macOS were more permissive and worked despite the mismatch — so this only manifests on Windows hosts.

## Changes
- Place CDC at the next free interface number for each mode: `2` in normal mode, `4` in config mode (new `ITF_NUM_CDC_CONFIG` used only in the config-mode descriptor).
- Correct the declared interface counts: `ITF_NUM_TOTAL = 4`, `ITF_NUM_TOTAL_CONFIG = 6`.

No change in behavior when `DH_DEBUG=OFF` (the entire block is gated on `#ifdef DH_DEBUG`).

## Test plan
- [x] Build with `-DDH_DEBUG=ON` and flash to laptop-side Pico. Device enumerates cleanly on Windows 11; `USB Serial Device (COMx)` appears for the CDC debug port and serial output works.
- [x] Build with `-DDH_DEBUG=OFF`: no descriptor changes (block excluded), device behaves identically to upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)