### PR TITLE
Fix spontaneous mouse jumps from composite keyboards (Fixes #151, #263)

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -325,6 +325,16 @@ void process_mouse_report(uint8_t *raw_report, int len, uint8_t itf, hid_interfa
     /* Interpret the mouse HID report, extract and save values we need. */
     extract_report_values(raw_report, len, state, &values, iface);
 
+    /* If nothing changed, don't send a report. This prevents composite keyboards
+       (e.g. QMK, Perixx) that expose a mouse HID interface from generating spurious
+       absolute position reports when they send zero-movement mouse reports during
+       keyboard events like layer changes or media key presses. */
+    if (values.move_x == 0 && values.move_y == 0 &&
+        values.wheel == 0 && values.pan == 0 &&
+        values.buttons == state->mouse_buttons) {
+        return;
+    }
+
     /* Calculate and update mouse pointer movement. */
     enum screen_pos_e switch_direction = update_mouse_position(state, &values);
 

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -326,9 +326,9 @@ void process_mouse_report(uint8_t *raw_report, int len, uint8_t itf, hid_interfa
     extract_report_values(raw_report, len, state, &values, iface);
 
     /* If nothing changed, don't send a report. This prevents composite keyboards
-       (e.g. QMK, Perixx) that expose a mouse HID interface from generating spurious
+       (e.g. QMK) that expose a mouse HID interface from generating spurious
        absolute position reports when they send zero-movement mouse reports during
-       keyboard events like layer changes or media key presses. */
+       keyboard events . */
     if (values.move_x == 0 && values.move_y == 0 &&
         values.wheel == 0 && values.pan == 0 &&
         values.buttons == state->mouse_buttons) {


### PR DESCRIPTION
This PR fixes a bug where where certain keyboards that expose both keyboard and mouse HID devices, including certain keyboards using the QMK firmware, would cause the mouse cursor to jump to its most recent parking position whenever keyboard input was received—but only on one of the two raspberry pi boards: the one receiving the forwarded message, the mouse board.

The fix adds an early return in `process_mouse_report` when the report contains zero movement and no button changes, effectively dropping the "empty" report instead of forwarding it. This prevents mouse cursor from jumping back to the previous parking position.

Fixes #151
Fixes #263

My own keyboard is made by Perixx, but it is also a composite keyboard and exhibited the exact same bug described in those two issues. I've compiled the updated firmware and tested this fix on my own system, and it seems to work well.
