### PR TITLE
Fix mouse movement threshold and stuck mouse button during virtual desktop switches

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -17,11 +17,15 @@
 #define ACCEL_POINTS 7
 
 /* Check if our upcoming mouse movement would result in having to switch outputs */
-enum screen_pos_e is_screen_switch_needed(int position, int offset) {
-    if (position + offset < MIN_SCREEN_COORD - global_state.config.jump_threshold)
+enum screen_pos_e is_screen_switch_needed(device_t *state, int position, int offset) {
+    output_t *output = &state->config.output[state->active_output];
+
+    int left_threshold = (output->pos != LEFT && output->screen_index == 1) ? state->config.jump_threshold : 0;
+    if (position + offset < MIN_SCREEN_COORD - left_threshold)
         return LEFT;
 
-    if (position + offset > MAX_SCREEN_COORD + global_state.config.jump_threshold)
+    int right_threshold = (output->pos != RIGHT && output->screen_index == 1) ? state->config.jump_threshold : 0;
+    if (position + offset > MAX_SCREEN_COORD + right_threshold)
         return RIGHT;
 
     return NONE;
@@ -109,7 +113,7 @@ enum screen_pos_e update_mouse_position(device_t *state, mouse_values_t *values)
     int offset_y = round(values->move_y * acceleration_factor * (current->speed_y >> reduce_speed));
 
     /* Determine if our upcoming movement would stay within the screen */
-    enum screen_pos_e switch_direction = is_screen_switch_needed(state->pointer_x, offset_x);
+    enum screen_pos_e switch_direction = is_screen_switch_needed(state, state->pointer_x, offset_x);
 
     /* Update movement */
     state->pointer_x = move_and_keep_on_screen(state->pointer_x, offset_x);
@@ -197,7 +201,7 @@ void switch_virtual_desktop_macos(device_t *state, int direction) {
     mouse_report_t move_relative_one = {
         .x = move,
         .mode = RELATIVE,
-        .buttons = state->mouse_buttons,
+        .buttons = 0,
     };
 
     output_mouse_report(&edge_position, state);

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -16,18 +16,36 @@
 #define MACOS_SWITCH_MOVE_COUNT 5
 #define ACCEL_POINTS 7
 
-/* Check if our upcoming mouse movement would result in having to switch outputs */
-enum screen_pos_e is_screen_switch_needed(device_t *state, int position, int offset) {
-    output_t *output = &state->config.output[state->active_output];
+uint16_t get_jump_threshold(output_t *output, enum screen_pos_e direction) {
+    const uint16_t NO_JUMP_THRESHOLD = 0;
 
-    /* Apply jump threshold only when crossing physical PC boundaries (screen_index == 1 and 
-       moving towards the other PC). Switching virtual desktops on the same PC has a 0 threshold. */
-    int left_threshold = (output->pos != LEFT && output->screen_index == 1) ? state->config.jump_threshold : 0;
-    if (position + offset < MIN_SCREEN_COORD - left_threshold)
+    /* If on non-main local screen, every possible switch is local */
+    if (output->screen_index > 1)
+        return NO_JUMP_THRESHOLD;
+
+    /* If on main screen but going away from the border, switch is local */
+    if (output->pos == direction && output->screen_index == 1)
+        return NO_JUMP_THRESHOLD;
+
+    /* ... in all other cases, switch is non-local (jump to another pc) */
+    return global_state.config.jump_threshold;
+}
+
+/* Check if our upcoming mouse movement would result in having to switch outputs */
+enum screen_pos_e is_screen_switch_needed(output_t *output, int position, int offset) {
+    enum screen_pos_e direction = (offset < 0) ? LEFT : RIGHT;
+
+    /* No position offset implies no switch needed. */
+    if (offset == 0)
+        return NONE;
+
+    /* Local switches (virtual desktop changes) have no gap, only cross-output jumps use threshold */
+    uint16_t threshold = get_jump_threshold(output, direction);
+
+    if (position + offset < MIN_SCREEN_COORD - threshold)
         return LEFT;
 
-    int right_threshold = (output->pos != RIGHT && output->screen_index == 1) ? state->config.jump_threshold : 0;
-    if (position + offset > MAX_SCREEN_COORD + right_threshold)
+    if (position + offset > MAX_SCREEN_COORD + threshold)
         return RIGHT;
 
     return NONE;
@@ -115,7 +133,7 @@ enum screen_pos_e update_mouse_position(device_t *state, mouse_values_t *values)
     int offset_y = round(values->move_y * acceleration_factor * (current->speed_y >> reduce_speed));
 
     /* Determine if our upcoming movement would stay within the screen */
-    enum screen_pos_e switch_direction = is_screen_switch_needed(state, state->pointer_x, offset_x);
+    enum screen_pos_e switch_direction = is_screen_switch_needed(current, state->pointer_x, offset_x);
 
     /* Update movement */
     state->pointer_x = move_and_keep_on_screen(state->pointer_x, offset_x);
@@ -333,6 +351,16 @@ void process_mouse_report(uint8_t *raw_report, int len, uint8_t itf, hid_interfa
 
     /* Interpret the mouse HID report, extract and save values we need. */
     extract_report_values(raw_report, len, state, &values, iface);
+
+    /* If nothing changed, don't send a report. This prevents composite keyboards
+       (e.g. QMK) that expose a mouse HID interface from generating spurious
+       absolute position reports when they send zero-movement mouse reports during
+       keyboard events. */
+    if (values.move_x == 0 && values.move_y == 0 &&
+        values.wheel == 0 && values.pan == 0 &&
+        values.buttons == state->mouse_buttons) {
+        return;
+    }
 
     /* Calculate and update mouse pointer movement. */
     enum screen_pos_e switch_direction = update_mouse_position(state, &values);

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -20,6 +20,8 @@
 enum screen_pos_e is_screen_switch_needed(device_t *state, int position, int offset) {
     output_t *output = &state->config.output[state->active_output];
 
+    /* Apply jump threshold only when crossing physical PC boundaries (screen_index == 1 and 
+       moving towards the other PC). Switching virtual desktops on the same PC has a 0 threshold. */
     int left_threshold = (output->pos != LEFT && output->screen_index == 1) ? state->config.jump_threshold : 0;
     if (position + offset < MIN_SCREEN_COORD - left_threshold)
         return LEFT;
@@ -201,6 +203,9 @@ void switch_virtual_desktop_macos(device_t *state, int direction) {
     mouse_report_t move_relative_one = {
         .x = move,
         .mode = RELATIVE,
+        /* Force buttons to 0 for relative movement to avoid duplicating the button 
+           press state, which would leave the relative HID mouse permanently stuck 
+           down if the user is dragging an item while switching desktops. */
         .buttons = 0,
     };
 


### PR DESCRIPTION
This PR addresses two related issues with mouse behavior during same-computer screen switches:

### 1. Screen switch threshold applied even though we're not switching computers

**Bug Description:**
The configured `jump_threshold` is applied universally to any screen boundary interaction. This means that users are forced to overcome the movement threshold when moving to an adjacent screen on the same computer.

**Steps to Reproduce:**
1. Configure a `jump_threshold` greater than 0.
2. Have multiple virtual desktops open on the same computer.
3. Move the mouse pointer to the edge of the screen adjacent to the next virtual desktop.
4. Observe that the virtual desktop switch does not occur immediately when the screen boundary is reached; instead, the user must continue moving the mouse to overcome the `jump_threshold`.

---

### 2. Mouse button stuck when dragging between screens on Mac.

**Bug Description:**
When dragging an item across virtual desktop boundaries on macOS, the mouse button becomes stuck down. This happens because the virtual desktop switch mechanism momentarily sends relative mouse movement reports that erroneously duplicate the 'Mouse Down' state, causing the OS to register a button press on a separate HID interface that never receives a corresponding 'Mouse Up' event.

**Steps to Reproduce:**
1. Use a macOS output with multiple virtual desktops.
2. Click and hold the mouse button to begin dragging an item (such as a window or a file).
3. While continuing to hold the mouse button down, drag the cursor to the edge of the screen to trigger a virtual desktop switch.
4. After the virtual desktop switches, release the physical mouse button.
5. Observe that the mouse button remains virtually held down by the system (the item is still being dragged and clicks are unresponsive).