### PR TITLE
Add optional edge double-tap requirement for output switching

### DIFF
--- a/src/defaults.c
+++ b/src/defaults.c
@@ -61,4 +61,7 @@ const config_t default_config = {
     .hotkey_toggle = HOTKEY_TOGGLE,
     .kbd_led_as_indicator = KBD_LED_AS_INDICATOR,
     .jump_threshold = JUMP_THRESHOLD,
+    .switch_double_tap_enable = SWITCH_DOUBLE_TAP_ENABLE,
+    .switch_double_tap_ms = SWITCH_DOUBLE_TAP_MS,
+    .switch_double_tap_margin = SWITCH_DOUBLE_TAP_MARGIN,
 };

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -15,7 +15,7 @@
 #include "misc.h"
 #include "screen.h"
 
-#define CURRENT_CONFIG_VERSION 8
+#define CURRENT_CONFIG_VERSION 9
 
 /*==============================================================================
  *  Configuration Data

--- a/src/include/structs.h
+++ b/src/include/structs.h
@@ -79,6 +79,12 @@ typedef struct {
     uint8_t enforce_ports;
     uint16_t jump_threshold;
 
+    /* Require a "double tap" against the screen edge before switching actual
+       outputs (does not affect virtual desktop switching). */
+    uint8_t switch_double_tap_enable;
+    uint16_t switch_double_tap_ms;
+    uint16_t switch_double_tap_margin;  // How far (screen coords) to pull back before re-tapping
+
     output_t output[NUM_SCREENS];
     uint32_t _reserved;
 
@@ -108,6 +114,11 @@ typedef struct {
     int16_t pointer_x; // Store and update the location of our mouse pointer
     int16_t pointer_y;
     int16_t mouse_buttons; // Store and update the state of mouse buttons
+
+    /* Edge "double tap" to switch actual outputs */
+    uint64_t last_edge_tap_time;         // Timestamp of the last registered edge tap
+    uint8_t last_edge_tap_direction;     // Direction of the last registered edge tap
+    bool edge_in_contact;                // True while cursor is continuously pressed against the edge
 
     config_t config;       // Device configuration, loaded from flash or defaults used
     queue_t hid_queue_out; // Queue that stores outgoing hid messages

--- a/src/include/user_config.h
+++ b/src/include/user_config.h
@@ -83,6 +83,29 @@
 #define ENABLE_ACCELERATION 1
 
 /**================================================== *
+ * ===========  Edge Double-Tap to Switch  ========= *
+ * ================================================== *
+ *
+ * When enabled, switching to the other computer (actual output) requires
+ * you to "double tap" the screen edge: push the cursor against the edge,
+ * pull away, then push against it again within a short time window. This
+ * helps prevent accidental switches. It only affects switches between
+ * physical outputs - virtual desktop switching is unaffected.
+ *
+ * SWITCH_DOUBLE_TAP_ENABLE: [0, 1] - 1 enables the double-tap requirement
+ * SWITCH_DOUBLE_TAP_MS: [0-2000] - max milliseconds allowed between the two taps
+ * SWITCH_DOUBLE_TAP_MARGIN: [0-32767] - how far (in screen coordinates) the
+ *   cursor must be pulled back from the edge before pressing against it again
+ *   counts as a second tap. Smaller = re-tap registers sooner. The full screen
+ *   width is 32767, so e.g. 1000 is roughly 3% of the screen.
+ *
+ * */
+
+#define SWITCH_DOUBLE_TAP_ENABLE 0
+#define SWITCH_DOUBLE_TAP_MS 300
+#define SWITCH_DOUBLE_TAP_MARGIN 1000
+
+/**================================================== *
  * ==============  Screensaver Config  ============== *
  * ================================================== *
  *

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -186,6 +186,15 @@ int16_t scale_y_coordinate(int screen_from, int screen_to, device_t *state) {
     return ((state->pointer_y - from->border.top) * MAX_SCREEN_COORD) / size_from;
 }
 
+/* Clear any pending edge double-tap arming. Called whenever the active screen
+   changes so a tap registered at one screen's edge can never carry over and
+   complete a switch at a different screen or edge. */
+static void reset_edge_tap(device_t *state) {
+    state->edge_in_contact         = false;
+    state->last_edge_tap_time      = 0;
+    state->last_edge_tap_direction = NONE;
+}
+
 void switch_to_another_pc(
     device_t *state, output_t *output, int output_to, int direction) {
     uint8_t *mouse_park_pos = &state->config.output[state->active_output].mouse_park_pos;
@@ -200,6 +209,9 @@ void switch_to_another_pc(
     set_active_output(state, output_to);
     state->pointer_x = (direction == LEFT) ? MAX_SCREEN_COORD : MIN_SCREEN_COORD;
     state->pointer_y = scale_y_coordinate(output->number, 1 - output->number, state);
+
+    /* New screen -> forget any half-completed double-tap. */
+    reset_edge_tap(state);
 }
 
 void switch_virtual_desktop_macos(device_t *state, int direction) {
@@ -255,6 +267,47 @@ void switch_virtual_desktop(device_t *state, output_t *output, int new_index, in
 
     state->pointer_x       = (direction == RIGHT) ? MIN_SCREEN_COORD : MAX_SCREEN_COORD;
     output->screen_index = new_index;
+
+    /* New screen -> forget any half-completed double-tap so a tap armed at the
+       output border can't complete after crossing between virtual desktops. */
+    reset_edge_tap(state);
+}
+
+/* Returns true if an actual-output switch is allowed to proceed right now.
+
+   When the "double tap" feature is enabled, the first time the cursor presses
+   against the edge only "arms" the switch - the user has to pull away from the
+   edge and press against it again (in the same direction) within the configured
+   time window for the switch to actually happen. This only gates switches
+   between physical outputs; virtual desktop switching never calls this. */
+static bool edge_double_tap_ready(device_t *state, int direction) {
+    /* Feature disabled -> always allow immediately (classic behavior). */
+    if (!state->config.switch_double_tap_enable)
+        return true;
+
+    /* Still pressed against the edge from an earlier report; a fresh tap only
+       counts once the cursor has been pulled away from the edge again. */
+    if (state->edge_in_contact)
+        return false;
+
+    /* We just (re)made contact with the edge - remember it so that continuously
+       pushing against the edge is treated as a single tap, not many. */
+    state->edge_in_contact = true;
+
+    uint64_t now       = time_us_64();
+    uint64_t window_us = (uint64_t)state->config.switch_double_tap_ms * 1000;
+
+    /* Second tap in the same direction within the time window -> switch now. */
+    if (state->last_edge_tap_direction == direction && (now - state->last_edge_tap_time) <= window_us) {
+        state->last_edge_tap_time      = 0;
+        state->last_edge_tap_direction = NONE;
+        return true;
+    }
+
+    /* Otherwise this is the first tap: record it and wait for the second one. */
+    state->last_edge_tap_time      = now;
+    state->last_edge_tap_direction = direction;
+    return false;
 }
 
 /*                               BORDER
@@ -277,6 +330,10 @@ void do_screen_switch(device_t *state, int direction) {
         if (output->screen_index == 1) { /* We are at the border -> switch outputs */
             /* No switching allowed if mouse button is held. Should only apply to the border! */
             if (state->mouse_buttons)
+                return;
+
+            /* Optionally require a "double tap" against the edge before switching. */
+            if (!edge_double_tap_ready(state, direction))
                 return;
 
             switch_to_another_pc(state, output, 1 - state->active_output, direction);
@@ -370,6 +427,16 @@ void process_mouse_report(uint8_t *raw_report, int len, uint8_t itf, hid_interfa
 
     /* Move the mouse, depending where the output is supposed to go */
     output_mouse_report(&report, state);
+
+    /* Release the edge only once the cursor has actually been pulled back onto
+       the screen by at least the configured margin. While it stays pinned
+       against the edge (even with vertical jitter) it remains "in contact", so
+       continuously leaning on the edge is treated as a single tap and won't
+       switch on its own. */
+    int16_t margin = state->config.switch_double_tap_margin;
+    if (state->pointer_x > MIN_SCREEN_COORD + margin &&
+        state->pointer_x < MAX_SCREEN_COORD - margin)
+        state->edge_in_contact = false;
 
     /* We use the mouse to switch outputs, if switch_direction is LEFT or RIGHT */
     if (switch_direction != NONE)

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -58,6 +58,9 @@ const field_map_t api_field_map[] = {
     { 75, false, UINT8,  1, offsetof(device_t, config.enable_acceleration) },
     { 76, false, UINT8,  1, offsetof(device_t, config.enforce_ports) },
     { 77, false, UINT16, 2, offsetof(device_t, config.jump_threshold) },
+    { 83, false, UINT8,  1, offsetof(device_t, config.switch_double_tap_enable) },
+    { 84, false, UINT16, 2, offsetof(device_t, config.switch_double_tap_ms) },
+    { 85, false, UINT16, 2, offsetof(device_t, config.switch_double_tap_margin) },
 
     /* Firmware */
     { 78, true,  UINT16, 2, offsetof(device_t, _running_fw.version) },

--- a/webconfig/form.py
+++ b/webconfig/form.py
@@ -31,6 +31,9 @@ CONFIG_ = [
     FormField(71, "Force Mouse Boot Mode", None, {}, "uint8", "checkbox"),
     FormField(75, "Enable Acceleration", None, {}, "uint8", "checkbox"),
     FormField(77, "Jump Threshold", 0, {"min": 0, "max": 3000}, "uint16", "range"),
+    FormField(83, "Edge Double-Tap to Switch", None, {}, "uint8", "checkbox"),
+    FormField(84, "Double-Tap Time (ms)", 300, {"min": 0, "max": 2000}, "uint16", "range"),
+    FormField(85, "Double-Tap Pull-Back Distance", 1000, {"min": 50, "max": 5000}, "uint16", "range"),
 
     FormField(1002, "Keyboard", elem="label"),
     FormField(72, "Force KBD Boot Protocol", None, {}, "uint8", "checkbox"),


### PR DESCRIPTION
## Summary

Adds an optional "double tap" gesture requirement before switching between physical outputs. When enabled, pushing the cursor into the screen edge no longer switches immediately — you press the edge, pull the cursor back onto the screen, then press the edge again within a configurable time window. This helps prevent accidental output switches.

Only switches between **physical outputs** are gated. Feature is **disabled by default**, so existing behavior is preserved.

## Configuration (web config → Mouse section)

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| Edge Double-Tap to Switch | checkbox | off | Enable/disable the requirement |
| Double-Tap Time (ms) | 0–2000 | 300 | Max time allowed between the two taps |
| Double-Tap Pull-Back Distance | 50–5000 | 1000 | How far the cursor must retreat from the edge (screen coords; full width = 32767) before a second tap registers |

All three also have `user_config.h` defaults (`SWITCH_DOUBLE_TAP_ENABLE`, `SWITCH_DOUBLE_TAP_MS`, `SWITCH_DOUBLE_TAP_MARGIN`).

## Implementation notes

- Gating lives in `do_screen_switch()` and only wraps the `switch_to_another_pc()`  path, so virtual-desktop switching is untouched.
- Edge "release" is detected from cursor position with a configurable margin (hysteresis), so holding against the edge — or minor sensor jitter while pressed — counts as a single tap and won't switch on its own.
- New `config_t` fields with API field-map entries (83/84/85); `CURRENT_CONFIG_VERSION` bumped so existing configs reset to defaults on first boot.

## Note on generated files

This PR intentionally changes only `form.py` (the web-config source) and the C code. The generated artifacts — `webconfig/config.htm`, `webconfig/config-unpacked.htm`, and `disk/disk.img` — need regenerating with the project's toolchain. I left them out because my environment reflows `config-unpacked.htm` entirely. The three new fields are defined in `form.py`.

## Testing

- Verified double-tap switching between two physical outputs (enable on/off, various time windows and pull-back distances).
- Confirmed holding against the edge does not switch, and that virtual desktop switching is unchanged.