### PR TITLE
Support boot-protocol keyboard for UEFI/BitLocker pre-boot

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -235,8 +235,15 @@ void process_kbd_queue_task(device_t *state) {
     if (!tud_hid_n_ready(ITF_NUM_HID))
         return;
 
-    /* ... try sending it to the host, if it's successful */
-    bool succeeded = tud_hid_keyboard_report(REPORT_ID_KEYBOARD, report.modifier, report.keycode);
+    /* ... try sending it to the host, if it's successful.
+       In boot protocol (UEFI/BIOS/BitLocker) the host expects the fixed 8-byte
+       boot keyboard report with NO report ID, so send the raw report struct
+       (modifier, reserved, 6 keycodes). Otherwise use the normal report-ID path. */
+    bool succeeded;
+    if (tud_hid_n_get_protocol(ITF_NUM_HID) == HID_PROTOCOL_BOOT)
+        succeeded = tud_hid_n_report(ITF_NUM_HID, 0, &report, sizeof(report));
+    else
+        succeeded = tud_hid_keyboard_report(REPORT_ID_KEYBOARD, report.modifier, report.keycode);
 
     /* ... then we can remove it from the queue. Race conditions shouldn't happen [tm] */
     if (succeeded)

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -391,6 +391,14 @@ void process_mouse_queue_task(device_t *state) {
     if (!queue_try_peek(&state->mouse_queue, &report))
         return;
 
+    /* In boot protocol (UEFI/BIOS/BitLocker) the shared HID interface only speaks the
+       8-byte boot keyboard format; an absolute mouse report would be misread as
+       keystrokes. Drop it instead of sending garbage. */
+    if (report.mode == ABSOLUTE && tud_hid_n_get_protocol(ITF_NUM_HID) == HID_PROTOCOL_BOOT) {
+        queue_try_remove(&state->mouse_queue, &report);
+        return;
+    }
+
     /* If we are suspended, let's wake the host up */
     if (tud_suspended())
         tud_remote_wakeup();

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -391,14 +391,6 @@ void process_mouse_queue_task(device_t *state) {
     if (!queue_try_peek(&state->mouse_queue, &report))
         return;
 
-    /* In boot protocol (UEFI/BIOS/BitLocker) the shared HID interface only speaks the
-       8-byte boot keyboard format; an absolute mouse report would be misread as
-       keystrokes. Drop it instead of sending garbage. */
-    if (report.mode == ABSOLUTE && tud_hid_n_get_protocol(ITF_NUM_HID) == HID_PROTOCOL_BOOT) {
-        queue_try_remove(&state->mouse_queue, &report);
-        return;
-    }
-
     /* If we are suspended, let's wake the host up */
     if (tud_suspended())
         tud_remote_wakeup();
@@ -406,6 +398,19 @@ void process_mouse_queue_task(device_t *state) {
     /* If it's not ready, we'll try on the next pass */
     if (!tud_hid_n_ready(ITF_NUM_HID))
         return;
+
+    /* In boot protocol (UEFI/BIOS/BitLocker) the shared HID interface only speaks the
+       8-byte boot keyboard format; an absolute mouse report would be misread as
+       keystrokes. Drop it instead of sending garbage. Asked below the readiness check
+       and not above it: hidd_reset() clears protocol_mode to zero, which is the same
+       value as HID_PROTOCOL_BOOT, so an interface no host has configured yet reads as
+       boot whether or not anything asked for it. tud_hid_n_ready() is false until
+       hidd_open() has run, and that is the call that gives protocol_mode its real
+       default. */
+    if (report.mode == ABSOLUTE && tud_hid_n_get_protocol(ITF_NUM_HID) == HID_PROTOCOL_BOOT) {
+        queue_try_remove(&state->mouse_queue, &report);
+        return;
+    }
 
     /* Try sending it to the host, if it's successful */
     bool succeeded

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -178,16 +178,20 @@ void process_hid_queue_task(device_t *state) {
     if (!queue_try_peek(&state->hid_queue_out, &packet))
         return;
 
+    if (!tud_hid_n_ready(packet.instance))
+        return;
+
     /* In boot protocol (UEFI/BIOS/BitLocker) the boot keyboard interface only speaks the
        8-byte boot keyboard format; report-ID reports (consumer/system) would be misread
-       as keystrokes, so drop them while boot protocol is active. */
+       as keystrokes, so drop them while boot protocol is active. Asked below the readiness
+       check and not above it: hidd_reset() clears protocol_mode to zero, which is the same
+       value as HID_PROTOCOL_BOOT, so an interface no host has configured yet reads as boot
+       whether or not anything asked for it. tud_hid_n_ready() is false until hidd_open()
+       has run, and that is the call that gives protocol_mode its real default. */
     if (packet.instance == ITF_NUM_HID && tud_hid_n_get_protocol(ITF_NUM_HID) == HID_PROTOCOL_BOOT) {
         queue_try_remove(&state->hid_queue_out, &packet);
         return;
     }
-
-    if (!tud_hid_n_ready(packet.instance))
-        return;
 
     /* ... try sending it to the host, if it's successful */
     bool succeeded = tud_hid_n_report(packet.instance, packet.report_id, packet.data, packet.len);

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -178,6 +178,14 @@ void process_hid_queue_task(device_t *state) {
     if (!queue_try_peek(&state->hid_queue_out, &packet))
         return;
 
+    /* In boot protocol (UEFI/BIOS/BitLocker) the boot keyboard interface only speaks the
+       8-byte boot keyboard format; report-ID reports (consumer/system) would be misread
+       as keystrokes, so drop them while boot protocol is active. */
+    if (packet.instance == ITF_NUM_HID && tud_hid_n_get_protocol(ITF_NUM_HID) == HID_PROTOCOL_BOOT) {
+        queue_try_remove(&state->hid_queue_out, &packet);
+        return;
+    }
+
     if (!tud_hid_n_ready(packet.instance))
         return;
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -20,12 +20,58 @@ _Static_assert(MAX_DEVICES <= CFG_TUH_DEVICE_MAX,
 
 /* Invoked when we get GET_REPORT control request.
  * We are expected to fill buffer with the report content, update reqlen
- * and return its length. We return 0 to STALL the request. */
+ * and return its length. We return 0 to STALL the request.
+ *
+ * Returning 0 for everything used to stall it every time, and a stall is the
+ * wrong answer for a report we do put in our own descriptor. It went unnoticed
+ * while nothing bound the keyboard interface, but a boot keyboard is driven by
+ * the firmware's own keyboard driver, which may ask. The HID spec makes
+ * Get_Report mandatory.
+ *
+ * Only ITF_NUM_HID has anything to answer with, being the interface that
+ * declares a keyboard input report and an LED output report. A boot-protocol
+ * host asks with no report ID at all and a report-protocol one asks by ID, so
+ * take both. TinyUSB writes the ID byte itself and shortens request_len to
+ * match whenever the ID is non-zero, so what belongs in the buffer here is the
+ * payload alone either way.
+ *
+ * Everything else still returns 0. That stalls, which is the correct answer for
+ * a report this device does not declare. */
 uint16_t tud_hid_get_report_cb(uint8_t instance,
                                uint8_t report_id,
                                hid_report_type_t report_type,
                                uint8_t *buffer,
                                uint16_t request_len) {
+    if (instance != ITF_NUM_HID)
+        return 0;
+
+    if (report_id != 0 && report_id != REPORT_ID_KEYBOARD)
+        return 0;
+
+    if (report_type == HID_REPORT_TYPE_OUTPUT) {
+        if (request_len < 1)
+            return 0;
+
+        /* What the host last asked for, which is also what the attached keyboard
+           was told, since kbd_led_as_indicator rewrites the bit before it is
+           stored rather than on the way out. */
+        buffer[0] = global_state.keyboard_leds_desired[BOARD_ROLE];
+
+        return 1;
+    }
+
+    if (report_type == HID_REPORT_TYPE_INPUT) {
+        hid_keyboard_report_t report;
+
+        if (request_len < sizeof(report))
+            return 0;
+
+        combine_kbd_states(&global_state, &report);
+        memcpy(buffer, &report, sizeof(report));
+
+        return sizeof(report);
+    }
+
     return 0;
 }
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -118,9 +118,11 @@ void tud_hid_set_report_cb(uint8_t instance,
     }
 
     /* Only other set report we care about is LED state change, and that's exactly 1 byte long.
-       It belongs to the keyboard interface, the only one of ours that declares an output report
-       at all. In boot protocol the host sends that report with no report ID in front of it, so
-       accept report ID 0 there too while boot protocol is the one in force. */
+       It belongs to the keyboard interface. The vendor interface declares an output report too,
+       twelve bytes wide on REPORT_ID_VENDOR and handled above, but no other interface of ours
+       has a one byte output report to offer this test, which is what makes scoping it to
+       ITF_NUM_HID sound. In boot protocol the host sends the LED report with no report ID in
+       front of it, so accept report ID 0 there too while boot protocol is the one in force. */
     bool is_led_report = instance == ITF_NUM_HID
                       && (report_id == REPORT_ID_KEYBOARD
                           || (report_id == 0

--- a/src/usb.c
+++ b/src/usb.c
@@ -58,9 +58,10 @@ uint16_t tud_hid_get_report_cb(uint8_t instance,
         if (request_len < 1)
             return 0;
 
-        /* What the host last asked for, which is also what the attached keyboard
-           was told, since kbd_led_as_indicator rewrites the bit before it is
-           stored rather than on the way out. */
+        /* What the host last set, after the Caps Lock rewrite kbd_led_as_indicator
+           makes before the byte is stored, so it is also what the attached keyboard
+           was told. With the indicator on, a host that turned Caps Lock off and
+           reads back sees it on while this board is the active output. */
         buffer[0] = global_state.keyboard_leds_desired[BOARD_ROLE];
 
         return 1;

--- a/src/usb.c
+++ b/src/usb.c
@@ -22,11 +22,13 @@ _Static_assert(MAX_DEVICES <= CFG_TUH_DEVICE_MAX,
  * We are expected to fill buffer with the report content, update reqlen
  * and return its length. We return 0 to STALL the request.
  *
- * Returning 0 for everything used to stall it every time, and a stall is the
- * wrong answer for a report we do put in our own descriptor. It went unnoticed
- * while nothing bound the keyboard interface, but a boot keyboard is driven by
- * the firmware's own keyboard driver, which may ask. The HID spec makes
- * Get_Report mandatory.
+ * Returning 0 for everything answered badly in two different ways. With a report
+ * ID the host gets a one-byte reply carrying nothing but the ID echoed back,
+ * since TinyUSB counts that byte before calling us. Without one, which is how a
+ * boot-protocol host asks, the count stays at zero and the request stalls. Both
+ * are wrong for a report we put in our own descriptor, and the HID spec makes
+ * Get_Report mandatory. It went unnoticed while nothing bound this interface as
+ * a keyboard, which a boot keyboard now does.
  *
  * Only ITF_NUM_HID has anything to answer with, being the interface that
  * declares a keyboard input report and an LED output report. A boot-protocol
@@ -61,12 +63,19 @@ uint16_t tud_hid_get_report_cb(uint8_t instance,
     }
 
     if (report_type == HID_REPORT_TYPE_INPUT) {
-        hid_keyboard_report_t report;
+        hid_keyboard_report_t report = {0};
 
         if (request_len < sizeof(report))
             return 0;
 
-        combine_kbd_states(&global_state, &report);
+        /* Only the computer being typed into is told what is held down. Key state is tracked
+           on whichever board the keyboard is plugged into, whatever output is selected, so
+           answering this from that state alone would let an idle computer read back, over its
+           own control pipe, what is being typed into the other one. It is told what it is
+           actually receiving, which is nothing. */
+        if (CURRENT_BOARD_IS_ACTIVE_OUTPUT)
+            combine_kbd_states(&global_state, &report);
+
         memcpy(buffer, &report, sizeof(report));
 
         return sizeof(report);

--- a/src/usb.c
+++ b/src/usb.c
@@ -62,8 +62,16 @@ void tud_hid_set_report_cb(uint8_t instance,
         process_packet(packet, &global_state);
     }
 
-    /* Only other set report we care about is LED state change, and that's exactly 1 byte long */
-    if (report_id != REPORT_ID_KEYBOARD || bufsize != 1 || report_type != HID_REPORT_TYPE_OUTPUT)
+    /* Only other set report we care about is LED state change, and that's exactly 1 byte long.
+       It belongs to the keyboard interface, the only one of ours that declares an output report
+       at all. In boot protocol the host sends that report with no report ID in front of it, so
+       accept report ID 0 there too while boot protocol is the one in force. */
+    bool is_led_report = instance == ITF_NUM_HID
+                      && (report_id == REPORT_ID_KEYBOARD
+                          || (report_id == 0
+                              && tud_hid_n_get_protocol(ITF_NUM_HID) == HID_PROTOCOL_BOOT));
+
+    if (!is_led_report || bufsize != 1 || report_type != HID_REPORT_TYPE_OUTPUT)
         return;
 
     uint8_t leds = buffer[0];

--- a/src/usb.c
+++ b/src/usb.c
@@ -30,15 +30,19 @@ _Static_assert(MAX_DEVICES <= CFG_TUH_DEVICE_MAX,
  * Get_Report mandatory. It went unnoticed while nothing bound this interface as
  * a keyboard, which a boot keyboard now does.
  *
- * Only ITF_NUM_HID has anything to answer with, being the interface that
- * declares a keyboard input report and an LED output report. A boot-protocol
- * host asks with no report ID at all and a report-protocol one asks by ID, so
- * take both. TinyUSB writes the ID byte itself and shortens request_len to
- * match whenever the ID is non-zero, so what belongs in the buffer here is the
- * payload alone either way.
+ * Answered here: the keyboard input report and the LED output report, both on
+ * ITF_NUM_HID. A boot-protocol host asks with no report ID at all and a
+ * report-protocol one asks by ID, so take both. TinyUSB writes the ID byte
+ * itself and shortens request_len to match whenever the ID is non-zero, so what
+ * belongs in the buffer here is the payload alone either way.
  *
- * Everything else still returns 0. That stalls, which is the correct answer for
- * a report this device does not declare. */
+ * Everything else still returns 0, and stalls. Some of that is declared by this
+ * device: the absolute mouse, consumer and system reports on this same
+ * interface, the relative mouse on ITF_NUM_HID_REL_M and the vendor report on
+ * ITF_NUM_HID_VENDOR. They stay stalled on purpose. Their idle state is all
+ * zero and says nothing a host could use, and the absolute mouse report is
+ * actively unsafe to answer that way: a host that feeds Get_Report answers into
+ * its input path reads x = 0, y = 0 as a jump to the top left corner. */
 uint16_t tud_hid_get_report_cb(uint8_t instance,
                                uint8_t report_id,
                                hid_report_type_t report_type,

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -199,9 +199,12 @@ uint8_t const desc_configuration[] = {
     TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 500),
 
     // Interface number, string index, protocol, report descriptor len, EP In address, size & polling interval
+    /* Declared as a boot keyboard (subclass=Boot, protocol=Keyboard) so UEFI/BIOS
+       pre-boot environments (e.g. BitLocker PIN entry) recognize it. In boot
+       protocol the keyboard send path emits the plain 8-byte report (see keyboard.c). */
     TUD_HID_DESCRIPTOR(ITF_NUM_HID,
                        STRID_PRODUCT,
-                       HID_ITF_PROTOCOL_NONE,
+                       HID_ITF_PROTOCOL_KEYBOARD,
                        sizeof(desc_hid_report),
                        EPNUM_HID,
                        CFG_TUD_HID_EP_BUFSIZE,
@@ -226,9 +229,12 @@ uint8_t const desc_configuration_config[] = {
     TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL_CONFIG, 0, CONFIG_TOTAL_LEN_CFG, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 500),
 
     // Interface number, string index, protocol, report descriptor len, EP In address, size & polling interval
+    /* Declared as a boot keyboard (subclass=Boot, protocol=Keyboard) so UEFI/BIOS
+       pre-boot environments (e.g. BitLocker PIN entry) recognize it. In boot
+       protocol the keyboard send path emits the plain 8-byte report (see keyboard.c). */
     TUD_HID_DESCRIPTOR(ITF_NUM_HID,
                        STRID_PRODUCT,
-                       HID_ITF_PROTOCOL_NONE,
+                       HID_ITF_PROTOCOL_KEYBOARD,
                        sizeof(desc_hid_report),
                        EPNUM_HID,
                        CFG_TUD_HID_EP_BUFSIZE,


### PR DESCRIPTION
Present the keyboard interface as a boot keyboard (subclass=Boot, protocol=Keyboard) so UEFI/BIOS pre-boot environments (e.g. BitLocker PIN entry) recognize it. When the host selects boot protocol, send the plain 8-byte boot keyboard report with no report ID, and drop absolute-mouse and consumer/system report-ID reports on that interface so they are not misread as keystrokes. Normal OS operation (report protocol) is unchanged.

I was having this same issue on my work laptop, and this seems to work for me. Hopefully resolves #122. 


Follow-up commits on this branch, each with its full account in its message:

- The LED output report a boot-protocol host sends with no report ID is now accepted, so Num Lock and Caps Lock follow the host in UEFI setup and at the BitLocker prompt.
- The interface's protocol is asked only once a host has configured it. TinyUSB's reset clears `protocol_mode` to zero, which is `HID_PROTOCOL_BOOT`, so before SET_CONFIGURATION every consumer, system and absolute mouse report on that interface was dropped as though a boot-protocol host were listening, when none was.
- Get_Report is answered for the keyboard input report and the LED output report, in the boot form and by report ID. The input answer goes only to the computer that is the selected output, so the idle one cannot read what is being typed into the other.
- Three comment corrections, so the tree says the same thing as the commit messages that corrected it.
