### PR TITLE
Fix cursor jumping when a pointing device is attached to each board (#263)

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -187,6 +187,20 @@ void handle_mouse_abs_uart_msg(uart_packet_t *packet, device_t *state) {
     state->last_activity[BOARD_ROLE] = time_us_64();
 }
 
+/* Adopt the authoritative cursor position from the other board.
+
+   Both boards track the cursor independently, but there is only one cursor. After an
+   output switch, the board that performed the switch knows where the cursor ended up,
+   so it tells us. Without this, our stale coordinates - in particular the parking
+   position from the hidden_pointer report in switch_to_another_pc - would be used the
+   next time a pointing device on THIS board moves, making the cursor jump in from a
+   screen corner. Worse, since the parked X sits right on the screen edge, the smallest
+   movement would immediately trigger an unwanted switch back. */
+void handle_pointer_sync_msg(uart_packet_t *packet, device_t *state) {
+    state->pointer_x = (int16_t)packet->data16[0];
+    state->pointer_y = (int16_t)packet->data16[1];
+}
+
 /* Function handles request to switch output  */
 void handle_output_select_msg(uart_packet_t *packet, device_t *state) {
     state->active_output = packet->data[0];

--- a/src/include/handlers.h
+++ b/src/include/handlers.h
@@ -49,6 +49,7 @@ void handle_keyboard_uart_msg(uart_packet_t *, device_t *);
 void handle_mouse_abs_uart_msg(uart_packet_t *, device_t *);
 void handle_mouse_zoom_msg(uart_packet_t *, device_t *);
 void handle_output_select_msg(uart_packet_t *, device_t *);
+void handle_pointer_sync_msg(uart_packet_t *, device_t *);
 void handle_proxy_msg(uart_packet_t *, device_t *);
 void handle_read_config_msg(uart_packet_t *, device_t *);
 void handle_reboot_msg(uart_packet_t *, device_t *);

--- a/src/include/mouse.h
+++ b/src/include/mouse.h
@@ -27,3 +27,4 @@ void process_mouse_report(uint8_t *, int, uint8_t, hid_interface_t *);
 void queue_mouse_report(mouse_report_t *, device_t *);
 bool tud_mouse_report(uint8_t mode, uint8_t buttons, int16_t x, int16_t y, int8_t wheel, int8_t pan);
 void output_mouse_report(mouse_report_t *, device_t *);
+void sync_pointer_position(device_t *);

--- a/src/include/protocol.h
+++ b/src/include/protocol.h
@@ -36,6 +36,7 @@ enum packet_type_e {
     PROXY_PACKET_MSG     = 23,
     REQUEST_BYTE_MSG     = 24,
     RESPONSE_BYTE_MSG    = 25,
+    POINTER_SYNC_MSG     = 26,
 };
 
 typedef enum {

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -200,6 +200,26 @@ void switch_to_another_pc(
     set_active_output(state, output_to);
     state->pointer_x = (direction == LEFT) ? MAX_SCREEN_COORD : MIN_SCREEN_COORD;
     state->pointer_y = scale_y_coordinate(output->number, 1 - output->number, state);
+
+    /* Tell the other board where the cursor actually ended up. There is only one
+       cursor but each board tracks it separately, and a pointing device may well be
+       attached to the other board (e.g. a keyboard with an integrated trackball).
+       This also overwrites the parking coordinates the hidden_pointer report above
+       just left there, which would otherwise be picked up as a real cursor position. */
+    sync_pointer_position(state);
+}
+
+/* Send our current cursor position to the other board so both agree where it is */
+void sync_pointer_position(device_t *state) {
+    uart_packet_t packet = {
+        .type = POINTER_SYNC_MSG,
+        .data16 = {
+            [0] = (uint16_t)state->pointer_x,
+            [1] = (uint16_t)state->pointer_y,
+        },
+    };
+
+    queue_try_add(&state->uart_tx_queue, &packet);
 }
 
 void switch_virtual_desktop_macos(device_t *state, int direction) {
@@ -370,6 +390,16 @@ void process_mouse_report(uint8_t *raw_report, int len, uint8_t itf, hid_interfa
 
     /* Move the mouse, depending where the output is supposed to go */
     output_mouse_report(&report, state);
+
+    /* There is one cursor, but each board tracks its position separately. When we are
+       not the active output, output_mouse_report already forwarded the full report and
+       the other board adopts our position from it. When we ARE the active output the
+       report stays local, so the other board would keep a stale position and any
+       pointing device attached to it (e.g. a keyboard with an integrated trackball)
+       would make the cursor jump back to wherever that board last thought it was.
+       Publish our position so both boards stay in agreement. */
+    if (CURRENT_BOARD_IS_ACTIVE_OUTPUT)
+        sync_pointer_position(state);
 
     /* We use the mouse to switch outputs, if switch_direction is LEFT or RIGHT */
     if (switch_direction != NONE)

--- a/src/uart.c
+++ b/src/uart.c
@@ -63,6 +63,7 @@ const uart_handler_t uart_handler[] = {
     {.type = KEYBOARD_REPORT_MSG, .handler = handle_keyboard_uart_msg},
     {.type = MOUSE_REPORT_MSG, .handler = handle_mouse_abs_uart_msg},
     {.type = OUTPUT_SELECT_MSG, .handler = handle_output_select_msg},
+    {.type = POINTER_SYNC_MSG, .handler = handle_pointer_sync_msg},
 
     /* Box control */
     {.type = MOUSE_ZOOM_MSG, .handler = handle_mouse_zoom_msg},


### PR DESCRIPTION
## Summary

Fixes the cursor jumping to a screen corner (and often triggering an unwanted output switch) when there is a pointing device attached to **both** boards — e.g. a keyboard with an integrated trackball on one and a regular mouse on the other. Hopefully this fully fixes #263.

## Root cause

Each board tracks `pointer_x/pointer_y` independently, but there is only one cursor. Position was only ever propagated in one direction: the non-active board forwards full mouse reports over UART and the active board adopts them. Nothing traveled back, so a pointing device on the active board would move the cursor while the other board kept a stale position.

Two visible symptoms:

1. **Jump in from a corner after switching.** `switch_to_another_pc()` sends a  `hidden_pointer` report to park the cursor in a corner of the outgoing screen. When that screen belongs to the other board, the report goes over UART and `handle_mouse_abs_uart_msg()` stores the *parking coordinates* as a real cursor position. The next movement from that board resumes from the corner — and since the parked X sits on the screen edge, even a tiny movement satisfies the edge check and triggers an immediate switch back.

2. **Snap to the other device's last position.** Alternating between the two pointing devices moved the cursor back to wherever the other board last recorded it.

## Changes

- New `POINTER_SYNC_MSG` packet type carrying the cursor's x/y.
- `sync_pointer_position()` publishes the current position to the other board.
- Sent at the end of `switch_to_another_pc()` (which also overwrites the parking coordinates left by the park report), and on movement when the board is the active output — the case where the report otherwise stays local.

No config, webconfig, or flash-layout changes.

## Testing

Verified on hardware with a pointing device on each board (mouse in the mouse port, a second mouse in the keyboard port):

- Alternating between the two devices no longer snaps the cursor.
- Crossing screens with one device then using the other no longer jumps in from the corner.
- Nudging the second device after crossing no longer causes an unwanted switch back.