### PR TITLE
Keep all key sections on keyboards that use more than one

### DIFF
--- a/src/hid_report.c
+++ b/src/hid_report.c
@@ -111,15 +111,32 @@ void handle_keyboard_descriptor_values(report_val_t *src, report_val_t *dst, hid
     /* Handle NKRO, normally size = 1, count = 240 or so, but they are swapped.
        The bitmap may be split across several usage ranges (Wooting keyboards use four,
        with padding in between to keep each one byte-aligned), so collect every block
-       instead of keeping only the last one we saw.
+       instead of keeping only the last one we saw. MAX_NKRO_BLOCKS is 4 and the Wooting
+       declares exactly 4, so there is no headroom: a keyboard splitting its bitmap five
+       ways still loses the last section, silently.
 
-       Recognise a block by its usage range mapping one usage per bit, which is what the
-       extraction below requires of it anyway. A size threshold is not good enough: one
-       of the Wooting ranges is only 8 bits wide, so a threshold drops it silently and
-       takes those keys with it. The modifier is the one small range that also maps one
-       usage per bit, and it is handled above, so leave it out here. Requiring a
-       non-empty range keeps out items that never carried a Usage Minimum/Maximum, where
-       both ends are still zero. */
+       A block is a run of keyboard usages laid out one per bit, which is what the
+       extraction below needs of it. The modifier is the one small run that also maps one
+       usage per bit, and it is handled above, so leave it out here. Requiring a non-empty
+       range keeps out items that never carried a Usage Minimum/Maximum, where both ends
+       are still zero.
+
+       The one-per-bit test is deliberately exact. Relaxing it to >= would admit the
+       Keychron Ultra-Link (19 00 2A 98 00 with 95 98: 153 usages over 152 bits), whose
+       bitmap is dropped here today - but that keyboard puts a 6KRO collection on report
+       ID 7 and its NKRO one on 0x11, and get_keyboard() collapses both onto a single
+       keyboard_t, because it answers with keyboards[PRIMARY_KEYBOARD] whenever
+       num_keyboards is 1 and num_keyboards can never reach 2 (is_found is only ever set
+       on slot 0). Recording the bitmap therefore sets is_nkro on the entry that also
+       carries report 7's key array, and every 6KRO report on that interface decodes as
+       bitmap bits instead - trading a keyboard that half works for one that does not.
+       Fix the collapse first; relaxing this without it is a regression.
+
+       Whether this keyboard *is* NKRO is then decided on the total width rather than per
+       block. Deciding per block would flag any keyboard carrying a stray keyboard-page
+       bit field - which routes it through _extract_kbd_nkro and leaves its ordinary key
+       array unread - while a per-block threshold big enough to avoid that would drop the
+       8-bit Wooting range and the keys in it. The sum separates the two cleanly. */
     bool maps_usage_per_bit = src->usage_max > src->usage_min
                               && (src->usage_max - src->usage_min + 1) == (int32_t)src->size;
 
@@ -128,13 +145,14 @@ void handle_keyboard_descriptor_values(report_val_t *src, report_val_t *dst, hid
 
     if (maps_usage_per_bit && !is_modifier && src->data_type == VARIABLE
         && keyboard->nkro_count < MAX_NKRO_BLOCKS) {
-        keyboard->is_nkro = true;
         keyboard->nkro[keyboard->nkro_count++] = (nkro_block_t){
             .offset    = src->offset,
             .size      = src->size,
             .usage_min = src->usage_min,
             .usage_max = src->usage_max,
         };
+        keyboard->nkro_bits += src->size;
+        keyboard->is_nkro = (keyboard->nkro_bits > NKRO_MIN_BITS);
     }
 
     /* We found a keyboard on this interface for a specific report id. */
@@ -266,12 +284,16 @@ void extract_data(hid_interface_t *iface, report_val_t *val) {
 }
 
 /* Walk one NKRO bitmap block, appending every pressed usage to dst. raw_report points at the
-   start of the report payload (report ID already skipped) and len is that payload's length. */
+   start of the report payload (report ID already skipped) and len is that payload's length.
+
+   Bounded by the block's bit count rather than by usage_max: a range declaring more usages
+   than the block has bits for is accepted at parse time, and the surplus has nowhere to
+   live. */
 int32_t extract_bit_variable(nkro_block_t *block, uint8_t *raw_report, int len, uint8_t *dst, int max_keys) {
     int key_count = 0;
 
-    for (int i = block->usage_min, j = block->offset; i <= block->usage_max && key_count < max_keys;
-         i++, j++) {
+    for (int bit = 0; bit < block->size && key_count < max_keys; bit++) {
+        int j          = block->offset + bit;
         int byte_index = j >> 3;
         int bit_index  = j & 0b111;
 
@@ -280,7 +302,7 @@ int32_t extract_bit_variable(nkro_block_t *block, uint8_t *raw_report, int len, 
             break;
 
         if (raw_report[byte_index] & (1 << bit_index)) {
-            dst[key_count++] = i;
+            dst[key_count++] = (uint8_t)(block->usage_min + bit);
         }
     }
 
@@ -331,12 +353,8 @@ int32_t _extract_kbd_nkro(uint8_t *raw_report, int len, hid_interface_t *iface, 
     if (kb->nkro_count == 0)
         return -1;
 
-    /* We expect every block to be an array of bits mapping 1:1 from usage_min to
-       usage_max, otherwise panic */
-    for (int i = 0; i < kb->nkro_count; i++) {
-        if ((kb->nkro[i].usage_max - kb->nkro[i].usage_min + 1) != kb->nkro[i].size)
-            return -1;
-    }
+    /* No 1:1 recheck here. handle_keyboard_descriptor_values applies exactly this test
+       before a block is ever recorded, so repeating it can only ever agree. */
 
     /* We expect modifier to be 8 bits long, otherwise we'll fallback to boot mode */
     if (kb->modifier.size != MODIFIER_BIT_LENGTH || kb->modifier.offset_idx >= len)

--- a/src/hid_report.c
+++ b/src/hid_report.c
@@ -109,10 +109,25 @@ void handle_keyboard_descriptor_values(report_val_t *src, report_val_t *dst, hid
     }
 
     /* Handle NKRO, normally size = 1, count = 240 or so, but they are swapped.
-       The bitmap may be split across several usage ranges (Wooting keyboards use three,
+       The bitmap may be split across several usage ranges (Wooting keyboards use four,
        with padding in between to keep each one byte-aligned), so collect every block
-       instead of keeping only the last one we saw. */
-    if (src->size > 32 && src->data_type == VARIABLE && keyboard->nkro_count < MAX_NKRO_BLOCKS) {
+       instead of keeping only the last one we saw.
+
+       Recognise a block by its usage range mapping one usage per bit, which is what the
+       extraction below requires of it anyway. A size threshold is not good enough: one
+       of the Wooting ranges is only 8 bits wide, so a threshold drops it silently and
+       takes those keys with it. The modifier is the one small range that also maps one
+       usage per bit, and it is handled above, so leave it out here. Requiring a
+       non-empty range keeps out items that never carried a Usage Minimum/Maximum, where
+       both ends are still zero. */
+    bool maps_usage_per_bit = src->usage_max > src->usage_min
+                              && (src->usage_max - src->usage_min + 1) == (int32_t)src->size;
+
+    bool is_modifier = src->size <= MODIFIER_BIT_LENGTH && LEFT_CTRL >= src->usage_min
+                       && LEFT_CTRL <= src->usage_max;
+
+    if (maps_usage_per_bit && !is_modifier && src->data_type == VARIABLE
+        && keyboard->nkro_count < MAX_NKRO_BLOCKS) {
         keyboard->is_nkro = true;
         keyboard->nkro[keyboard->nkro_count++] = (nkro_block_t){
             .offset    = src->offset,

--- a/src/hid_report.c
+++ b/src/hid_report.c
@@ -108,10 +108,18 @@ void handle_keyboard_descriptor_values(report_val_t *src, report_val_t *dst, hid
         keyboard->key_array[src->offset_idx] = (src->data_type == ARRAY);
     }
 
-    /* Handle NKRO, normally size = 1, count = 240 or so, but they are swapped. */
-    if (src->size > 32 && src->data_type == VARIABLE) {
+    /* Handle NKRO, normally size = 1, count = 240 or so, but they are swapped.
+       The bitmap may be split across several usage ranges (Wooting keyboards use three,
+       with padding in between to keep each one byte-aligned), so collect every block
+       instead of keeping only the last one we saw. */
+    if (src->size > 32 && src->data_type == VARIABLE && keyboard->nkro_count < MAX_NKRO_BLOCKS) {
         keyboard->is_nkro = true;
-        keyboard->nkro    = *src;
+        keyboard->nkro[keyboard->nkro_count++] = (nkro_block_t){
+            .offset    = src->offset,
+            .size      = src->size,
+            .usage_min = src->usage_min,
+            .usage_max = src->usage_max,
+        };
     }
 
     /* We found a keyboard on this interface for a specific report id. */
@@ -242,13 +250,19 @@ void extract_data(hid_interface_t *iface, report_val_t *val) {
     }
 }
 
-int32_t extract_bit_variable(report_val_t *kbd, uint8_t *raw_report, int len, uint8_t *dst) {
+/* Walk one NKRO bitmap block, appending every pressed usage to dst. raw_report points at the
+   start of the report payload (report ID already skipped) and len is that payload's length. */
+int32_t extract_bit_variable(nkro_block_t *block, uint8_t *raw_report, int len, uint8_t *dst, int max_keys) {
     int key_count = 0;
-    int bit_offset = kbd->offset & 0b111;
 
-    for (int i = kbd->usage_min, j = bit_offset; i <= kbd->usage_max && key_count < len; i++, j++) {
+    for (int i = block->usage_min, j = block->offset; i <= block->usage_max && key_count < max_keys;
+         i++, j++) {
         int byte_index = j >> 3;
         int bit_index  = j & 0b111;
+
+        /* Report is shorter than the descriptor claims, don't read past the end of it */
+        if (byte_index >= len)
+            break;
 
         if (raw_report[byte_index] & (1 << bit_index)) {
             dst[key_count++] = i;
@@ -291,25 +305,37 @@ int32_t _extract_kbd_other(uint8_t *raw_report, int len, hid_interface_t *iface,
 int32_t _extract_kbd_nkro(uint8_t *raw_report, int len, hid_interface_t *iface, hid_keyboard_report_t *report) {
     keyboard_t *kb = get_keyboard(iface, raw_report[0]);
     uint8_t *ptr = raw_report;
+    int key_count = 0;
 
     /* Skip report ID */
-    if (iface->uses_report_id)
+    if (iface->uses_report_id) {
         ptr++;
+        len--;
+    }
 
-    /* We expect array of bits mapping 1:1 from usage_min to usage_max, otherwise panic */
-    if ((kb->nkro.usage_max - kb->nkro.usage_min + 1) != kb->nkro.size)
+    if (kb->nkro_count == 0)
         return -1;
+
+    /* We expect every block to be an array of bits mapping 1:1 from usage_min to
+       usage_max, otherwise panic */
+    for (int i = 0; i < kb->nkro_count; i++) {
+        if ((kb->nkro[i].usage_max - kb->nkro[i].usage_min + 1) != kb->nkro[i].size)
+            return -1;
+    }
 
     /* We expect modifier to be 8 bits long, otherwise we'll fallback to boot mode */
-    if (kb->modifier.size == MODIFIER_BIT_LENGTH) {
-        report->modifier = ptr[kb->modifier.offset_idx];
-    } else
+    if (kb->modifier.size != MODIFIER_BIT_LENGTH || kb->modifier.offset_idx >= len)
         return -1;
 
-    /* Move the pointer to the nkro offset's byte index */
-    ptr = &ptr[kb->nkro.offset_idx];
+    report->modifier = ptr[kb->modifier.offset_idx];
 
-    return extract_bit_variable(&kb->nkro, ptr, KEYS_IN_USB_REPORT, report->keycode);
+    /* Collect keys from every bitmap block until the outgoing 6KRO report is full */
+    for (int i = 0; i < kb->nkro_count && key_count < KEYS_IN_USB_REPORT; i++) {
+        key_count += extract_bit_variable(
+            &kb->nkro[i], ptr, len, &report->keycode[key_count], KEYS_IN_USB_REPORT - key_count);
+    }
+
+    return key_count;
 }
 
 int32_t extract_kbd_data(

--- a/src/include/hid_parser.h
+++ b/src/include/hid_parser.h
@@ -23,6 +23,7 @@
 #define MAX_DEVICES                 4
 #define MAX_INTERFACES              12  // Per device; allows for complex devices like QMK
 #define MAX_KEYS                    32
+#define MAX_NKRO_BLOCKS             4
 #define MAX_REPORTS                 24
 #define MAX_KEYBOARDS               5
 #define MAX_SYS_BUTTONS             8
@@ -115,16 +116,27 @@ typedef struct {
 typedef struct hid_interface_t hid_interface_t;
 typedef void (*process_report_f)(uint8_t *, int, uint8_t, hid_interface_t *);
 
+/* One contiguous run of NKRO bitmap bits. Keyboards often split the bitmap into several
+   usage ranges with padding in between (to keep sections byte-aligned), so a single
+   offset/usage_min/usage_max triplet can't describe the whole thing. */
+typedef struct TU_ATTR_PACKED {
+    uint16_t offset;    // In bits, from the start of the report (report ID excluded)
+    uint16_t size;      // In bits
+    uint16_t usage_min;
+    uint16_t usage_max;
+} nkro_block_t;
+
 /* Defines information about HID report format for the keyboard. */
 typedef struct {
     report_val_t modifier;
-    report_val_t nkro;
+    nkro_block_t nkro[MAX_NKRO_BLOCKS];
     uint16_t cc_array[MAX_CC_BUTTONS];
     uint16_t sys_array[MAX_SYS_BUTTONS];
     bool key_array[MAX_KEYS];
 
     uint8_t report_id;
     uint8_t key_array_idx;
+    uint8_t nkro_count;
 
     bool uses_report_id;
     bool is_found;

--- a/src/include/hid_parser.h
+++ b/src/include/hid_parser.h
@@ -24,6 +24,11 @@
 #define MAX_INTERFACES              12  // Per device; allows for complex devices like QMK
 #define MAX_KEYS                    32
 #define MAX_NKRO_BLOCKS             4
+/* Total bitmap width, across every block, below which a keyboard is not treated as
+   NKRO. Restates the threshold the single-block code used, but applied to the sum:
+   one narrow block is padding or a stray bit field, several adding up to this are a
+   real key bitmap. */
+#define NKRO_MIN_BITS               32
 #define MAX_REPORTS                 24
 #define MAX_KEYBOARDS               5
 #define MAX_SYS_BUTTONS             8
@@ -137,6 +142,7 @@ typedef struct {
     uint8_t report_id;
     uint8_t key_array_idx;
     uint8_t nkro_count;
+    uint16_t nkro_bits;   // Sum of nkro[].size, what is_nkro is decided on
 
     bool uses_report_id;
     bool is_found;

--- a/src/include/keyboard.h
+++ b/src/include/keyboard.h
@@ -18,7 +18,7 @@
  *  Data Extraction
  *==============================================================================*/
 
-int32_t    extract_bit_variable(report_val_t *, uint8_t *, int, uint8_t *);
+int32_t    extract_bit_variable(nkro_block_t *, uint8_t *, int, uint8_t *, int);
 int32_t    extract_kbd_data(uint8_t *, int, uint8_t, hid_interface_t *, hid_keyboard_report_t *);
 keyboard_t *get_keyboard(hid_interface_t *iface, uint8_t report_id);
 


### PR DESCRIPTION
Hi, I had a go at issue #335.

As far as I can tell, the problem is that some keyboards list their keys in several separate sections rather than one long run. The code was only keeping the last section it came across, so everything in the earlier ones got dropped. On that Wooting the modifier keys are stored separately, which is why those kept working while nothing else did.

This change keeps all of the sections instead of only the last one.

Looking at it more closely, the Wooting actually has four sections, and one of them is only 8 bits wide. The old code worked out what counted as a key section by its size, so that short one got thrown away as well. Rather than going by size, it now looks for a section whose usage range lines up one usage per bit, which is what the extraction code already expects of anything handed to it. The modifier is the only small section that also looks like that, and it is dealt with just above, so it is left out here.

I also added a small length check so a report that comes in shorter than expected cannot read past the end of the buffer.

To test it I put together a little program that runs the real parsing code on my PC against the descriptor posted in the issue, and the keys come out right now. I also checked a plain keyboard, a normal NKRO keyboard and a composite dongle, and they parse exactly the same as before. It is here in case it is useful to anyone: https://github.com/mglushko/deskhop-hidtests

I do not own this keyboard, so I have not been able to try it on real hardware. Very happy to change anything or drop it if you would rather solve it another way.
