### PR TITLE
Firmware upgrade over the inter-board link never terminates

### DIFF
--- a/src/tasks.c
+++ b/src/tasks.c
@@ -197,8 +197,10 @@ void firmware_upgrade_task(device_t *state) {
     if (queue_is_full(&state->uart_tx_queue))
         return;
 
-    /* If we're on the last element of the current page, page is done - write it. */
-    if (TU_U32_BYTE0(state->fw.address) == 0x00) {
+    /* If we're on the last element of the current page, page is done - write it.
+       Address zero is not the end of a page: nothing has arrived yet, and
+       (0 - 1) & 0xFFFFFF00 would put the target below ADDR_FW_RUNNING. */
+    if (TU_U32_BYTE0(state->fw.address) == 0x00 && state->fw.address != 0) {
 
         uint32_t page_start_addr = (state->fw.address - 1) & 0xFFFFFF00;
         write_flash_page((uint32_t)ADDR_FW_RUNNING + page_start_addr - XIP_BASE, state->page_buffer);

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -197,8 +197,22 @@ void firmware_upgrade_task(device_t *state) {
     if (queue_is_full(&state->uart_tx_queue))
         return;
 
-    /* End condition, when reached the process is completed. */
-    if (state->fw.address > STAGING_IMAGE_SIZE) {
+    /* If we're on the last element of the current page, page is done - write it. */
+    if (TU_U32_BYTE0(state->fw.address) == 0x00) {
+
+        uint32_t page_start_addr = (state->fw.address - 1) & 0xFFFFFF00;
+        write_flash_page((uint32_t)ADDR_FW_RUNNING + page_start_addr - XIP_BASE, state->page_buffer);
+    }
+
+    /* End condition, when reached the process is completed.
+
+       Checked after the page write above, so the final page is in flash before
+       the checksum is taken over it, and reached AT the image size rather than
+       past it. The address only advances when a response arrives, and
+       handle_request_byte_msg returns without answering anything at or beyond
+       STAGING_IMAGE_SIZE - so waiting for the address to exceed it is waiting
+       for a response that is never sent. */
+    if (state->fw.address >= STAGING_IMAGE_SIZE) {
         state->fw.upgrade_in_progress = 0;
         state->fw.checksum = ~state->fw.checksum;
 
@@ -212,13 +226,8 @@ void firmware_upgrade_task(device_t *state) {
             state->_running_fw = _firmware_metadata;
             global_state.reboot_requested = true;
         }
-    }
 
-    /* If we're on the last element of the current page, page is done - write it. */
-    if (TU_U32_BYTE0(state->fw.address) == 0x00) {
-
-        uint32_t page_start_addr = (state->fw.address - 1) & 0xFFFFFF00;
-        write_flash_page((uint32_t)ADDR_FW_RUNNING + page_start_addr - XIP_BASE, state->page_buffer);
+        return;
     }
 
     request_byte(state, state->fw.address);


### PR DESCRIPTION
The board-to-board firmware upgrade can't finish. It writes the whole image correctly and then waits forever for a response that is never sent, on every upgrade.

## The bug

Two bounds that can't both be satisfied.

`firmware_upgrade_task` (`src/tasks.c`) completes when the address passes the image:

```c
if (state->fw.address > STAGING_IMAGE_SIZE) {
```

so it needs `fw.address` to reach `STAGING_IMAGE_SIZE + 4`. The address only advances in `handle_response_byte_msg`, so getting there requires a response for `STAGING_IMAGE_SIZE` itself.

But `handle_request_byte_msg` (`src/handlers.c`) refuses exactly that address:

```c
if (address >= STAGING_IMAGE_SIZE)
    return;
```

The last request is never answered. `byte_done` stays false, nothing retries, and the receiving board sits in `firmware_upgrade_task`'s early return indefinitely with `upgrade_in_progress` still set.

## Why it looks like it works

Every page has been written by the time the address reaches `STAGING_IMAGE_SIZE` — the image in flash is complete and correct. Only the handshake is missing: the checksum is never verified, `_running_fw` is never updated, and `reboot_requested` is never set.

So a power cycle at that point boots the new firmware and the upgrade appears to have succeeded. What's actually happened is that the transfer stopped one unanswered request from the end. Until that replug, the receiving board is stuck with `upgrade_in_progress` set, which on current `main` also means it stops emitting heartbeats — `heartbeat_output_task` returns early on that flag.

`git log -S` puts the end condition in 1415c1d (v0.61) and the range check in b65e8eb ("Bugfixes, range checks"). Each is reasonable alone; together they deadlock.

## The fix

Write the last page before checking the end condition, and check it *at* `STAGING_IMAGE_SIZE` rather than past it. Reaching that address means the final response has arrived and the write above has just put it in flash, so the image is whole and the checksum can be taken. The unanswerable request is never sent.

Second commit is a separate one-line bug in the same function, split out so it can be dropped independently: the page write also fires at address 0, before anything has been received, where `(0 - 1) & 0xFFFFFF00` puts the target 256 bytes below `ADDR_FW_RUNNING` and underflows to flash offset `0xFFFFFF00`. `handle_heartbeat_msg` starts an upgrade with `address = 0` and `byte_done = true`, so it happens once per upgrade.

## Verification

Found and measured on a pair of Picos while chasing a "board goes silent after an upgrade" symptom in a fork of this code.

Before: the receiving board held a complete image in flash, emitted no heartbeats, and needed a power cycle to come up on the new version. After the equivalent change: it verifies the checksum, reboots itself, and both boards report the new version with no intervention.

To be precise about what was tested — the hardware runs a fork with this change plus unrelated ones. The patch here is the same change applied to current `main`, which I haven't separately flashed. Happy to do that if useful.

Related: #312 touches this file and would conflict lightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JVZF1pr8w5dWd1uMa8kMV