### PR TITLE
Combine mouse buttons from every pointing device (#287)

### DIFF
--- a/src/handlers.c
+++ b/src/handlers.c
@@ -180,11 +180,29 @@ void handle_mouse_abs_uart_msg(uart_packet_t *packet, device_t *state) {
     mouse_report_t *mouse_report = (mouse_report_t *)packet->data;
     queue_mouse_report(mouse_report, state);
 
+    /* The buttons in this report are already the union across both boards, so it goes to
+       the host as it arrived. state->mouse_buttons is not touched here: MOUSE_BUTTONS_MSG
+       below is what maintains it, and one owner is what keeps the two halves in step. */
     state->pointer_x       = mouse_report->x;
     state->pointer_y       = mouse_report->y;
-    state->mouse_buttons   = mouse_report->buttons;
 
     state->last_activity[BOARD_ROLE] = time_us_64();
+}
+
+/* Take note of which mouse buttons are held down on devices attached to the other board.
+
+   There is one cursor and one set of buttons, but a pointing device may be attached to
+   either board (a keyboard with mouse keys on one, a trackball on the other), and each
+   report carries only its own sender's buttons. Each board sends its local union here
+   whenever it changes, and both then hold the same combined answer. That matters beyond
+   the report itself: do_screen_switch refuses to switch outputs while a button is held, and
+   it can now see a button held on the other board.
+
+   This one arrives on the edge, so it is what makes a press felt immediately. The
+   heartbeat below carries the same value as a level once a second, which is what makes a
+   missed edge heal. */
+void handle_mouse_buttons_msg(uart_packet_t *packet, device_t *state) {
+    set_remote_mouse_buttons(state, packet->data[0]);
 }
 
 /* Function handles request to switch output  */
@@ -360,6 +378,16 @@ void handle_response_byte_msg(uart_packet_t *packet, device_t *state) {
 /* Process a request to read a firmware package from flash */
 void handle_heartbeat_msg(uart_packet_t *packet, device_t *state) {
     uint16_t other_running_version = packet->data16[0];
+
+    /* Before the early returns below, and deliberately. MOUSE_BUTTONS_MSG only arrives
+       when the other board's half of the union changes, so nothing repairs a message that
+       was dropped, or a board that restarted or lost its mouse while a button was held:
+       this side would go on holding a button nobody is pressing, telling its computer so
+       on every move of its own and refusing to hand the cursor over. This is the same
+       number sent as a level once a second, so any of those heals within a second. A board
+       on older firmware leaves the field zero, which is the right answer for one that never
+       announces buttons at all. */
+    set_remote_mouse_buttons(state, (uint8_t)packet->data16[1]);
 
     if (state->fw.upgrade_in_progress)
         return;

--- a/src/include/handlers.h
+++ b/src/include/handlers.h
@@ -47,6 +47,7 @@ void handle_toggle_gaming_msg(uart_packet_t *, device_t *);
 void handle_heartbeat_msg(uart_packet_t *, device_t *);
 void handle_keyboard_uart_msg(uart_packet_t *, device_t *);
 void handle_mouse_abs_uart_msg(uart_packet_t *, device_t *);
+void handle_mouse_buttons_msg(uart_packet_t *, device_t *);
 void handle_mouse_zoom_msg(uart_packet_t *, device_t *);
 void handle_output_select_msg(uart_packet_t *, device_t *);
 void handle_proxy_msg(uart_packet_t *, device_t *);

--- a/src/include/hid_parser.h
+++ b/src/include/hid_parser.h
@@ -147,6 +147,13 @@ struct hid_interface_t {
     process_report_f report_handler[MAX_REPORTS];
     uint8_t protocol;
     bool uses_report_id;
+
+    /* Which mouse buttons this interface is currently holding down. The one member here
+       that keeps changing after the device is set up: everything above is either read out
+       of the descriptor or, in protocol's case, settled during enumeration. It lives here
+       because the interface is what identifies the device it came from, and because
+       tuh_hid_umount_cb clears the whole struct, so unplugging drops these too. */
+    uint8_t mouse_buttons;
 };
 
 typedef struct {

--- a/src/include/mouse.h
+++ b/src/include/mouse.h
@@ -24,6 +24,8 @@ void      parse_report_descriptor(hid_interface_t *, uint8_t const *, int);
  *  Mouse Report Handling
  *==============================================================================*/
 void process_mouse_report(uint8_t *, int, uint8_t, hid_interface_t *);
+uint8_t refresh_local_mouse_buttons(device_t *);
+void set_remote_mouse_buttons(device_t *, uint8_t);
 void queue_mouse_report(mouse_report_t *, device_t *);
 bool tud_mouse_report(uint8_t mode, uint8_t buttons, int16_t x, int16_t y, int8_t wheel, int8_t pan);
 void output_mouse_report(mouse_report_t *, device_t *);

--- a/src/include/protocol.h
+++ b/src/include/protocol.h
@@ -36,6 +36,7 @@ enum packet_type_e {
     PROXY_PACKET_MSG     = 23,
     REQUEST_BYTE_MSG     = 24,
     RESPONSE_BYTE_MSG    = 25,
+    MOUSE_BUTTONS_MSG    = 27,
 };
 
 typedef enum {

--- a/src/include/structs.h
+++ b/src/include/structs.h
@@ -107,7 +107,14 @@ typedef struct {
 
     int16_t pointer_x; // Store and update the location of our mouse pointer
     int16_t pointer_y;
-    int16_t mouse_buttons; // Store and update the state of mouse buttons
+    int16_t mouse_buttons; // Which buttons the output PC is being told are held down
+
+    /* A mouse report carries the full button state of the device that sent it, so the
+       one the host sees has to be the union across every device on both boards, the
+       same problem combine_kbd_states solves for keyboards. Each interface keeps what
+       it holds (hid_interface_t.mouse_buttons); these two are the halves of the union. */
+    uint8_t local_mouse_buttons;  // Union over devices on this board, and what we last announced
+    uint8_t remote_mouse_buttons; // Union over devices on the other board, as it last told us
 
     config_t config;       // Device configuration, loaded from flash or defaults used
     queue_t hid_queue_out; // Queue that stores outgoing hid messages

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -139,9 +139,6 @@ enum screen_pos_e update_mouse_position(device_t *state, mouse_values_t *values)
     state->pointer_x = move_and_keep_on_screen(state->pointer_x, offset_x);
     state->pointer_y = move_and_keep_on_screen(state->pointer_y, offset_y);
 
-    /* Update buttons state */
-    state->mouse_buttons = values->buttons;
-
     return switch_direction;
 }
 
@@ -320,8 +317,14 @@ void extract_report_values(uint8_t *raw_report, int len, device_t *state, mouse_
     extract_value(uses_id, &values->wheel, &mouse->wheel, raw_report, len);
     extract_value(uses_id, &values->pan, &mouse->pan, raw_report, len);
 
+    /* Buttons live under a different report ID than the axes on some devices (the
+       Kensington Expert Mouse puts them on report 1 and X/Y on report 2), so a movement
+       report says nothing about them and we keep what this interface last held. Reading
+       state->mouse_buttons here would hand back the union across every device and store
+       another device's bits in this one's slot, where they would stay held after that
+       device let go. */
     if (!extract_value(uses_id, &values->buttons, &mouse->buttons, raw_report, len)) {
-        values->buttons = state->mouse_buttons;
+        values->buttons = iface->mouse_buttons;
     }
 }
 
@@ -345,6 +348,54 @@ mouse_report_t create_mouse_report(device_t *state, mouse_values_t *values) {
     return mouse_report;
 }
 
+/* What every pointing device on this board is holding down, taken together.
+
+   Each report carries its sender's complete button state, so a trackball reporting
+   movement with nothing pressed says "no buttons" just as loudly as a keyboard's mouse
+   keys say "left down". Taking the last report at its word lets one device release the
+   other's buttons in the middle of a drag (issue #287). The union is the same answer
+   combine_kbd_states gives for keyboards.
+
+   Keyed on the interface rather than on the device index process_mouse_report is handed:
+   tuh_hid_report_received_cb gives every mouse interface index 1, so two mice would share
+   one slot.
+
+   Walked afresh each time rather than kept as a running total, because an interface can
+   also stop existing: tuh_hid_umount_cb memsets the whole struct, and a total would still
+   be carrying what the departed device held. */
+static uint8_t combine_local_mouse_buttons(device_t *state) {
+    uint8_t buttons = 0;
+
+    for (int dev = 0; dev < MAX_DEVICES; dev++)
+        for (int idx = 0; idx < MAX_INTERFACES; idx++)
+            buttons |= state->iface[dev][idx].mouse_buttons;
+
+    return buttons;
+}
+
+/* Work out this board's half of the union again and return it, keeping what the output PC
+   is told in step. Called on every mouse report, and once a second from the heartbeat so
+   that a device which simply stopped existing is noticed even though no report arrived to
+   say so. */
+uint8_t refresh_local_mouse_buttons(device_t *state) {
+    state->local_mouse_buttons = combine_local_mouse_buttons(state);
+    state->mouse_buttons       = state->local_mouse_buttons | state->remote_mouse_buttons;
+
+    return state->local_mouse_buttons;
+}
+
+/* Take note of the other board's half, keeping what the output PC is told in step. Both
+   messages that carry that half come through here - MOUSE_BUTTONS_MSG on every change, and
+   the heartbeat once a second as the level that corrects a missed one - so the two cannot
+   come to different conclusions.
+
+   Between them, these two are the only writers of state->mouse_buttons, and each restates
+   the whole union rather than editing half of it. */
+void set_remote_mouse_buttons(device_t *state, uint8_t buttons) {
+    state->remote_mouse_buttons = buttons;
+    state->mouse_buttons        = state->local_mouse_buttons | state->remote_mouse_buttons;
+}
+
 void process_mouse_report(uint8_t *raw_report, int len, uint8_t itf, hid_interface_t *iface) {
     mouse_values_t values = {0};
     device_t *state = &global_state;
@@ -352,15 +403,39 @@ void process_mouse_report(uint8_t *raw_report, int len, uint8_t itf, hid_interfa
     /* Interpret the mouse HID report, extract and save values we need. */
     extract_report_values(raw_report, len, state, &values, iface);
 
+    /* Narrowed to what the report going out can carry, since mouse_report_t.buttons is a
+       single byte. A device that declares more than eight buttons (the Logi Bolt receiver
+       declares sixteen) is then compared and stored in the width it will be sent in,
+       rather than held at full width here and truncated on the way out. */
+    uint8_t buttons = (uint8_t)values.buttons;
+
     /* If nothing changed, don't send a report. This prevents composite keyboards
        (e.g. QMK) that expose a mouse HID interface from generating spurious
        absolute position reports when they send zero-movement mouse reports during
-       keyboard events. */
+       keyboard events. Compared against what THIS interface last held: against the
+       union, a device holding nothing would stop matching the moment another one
+       pressed a button, and every idle report would get through again. */
     if (values.move_x == 0 && values.move_y == 0 &&
         values.wheel == 0 && values.pan == 0 &&
-        values.buttons == state->mouse_buttons) {
+        buttons == iface->mouse_buttons) {
         return;
     }
+
+    /* Remember what this device holds, then send the union of everything held anywhere.
+       Done before update_mouse_position so do_screen_switch, further down, still reads a
+       current state->mouse_buttons when it decides whether a button is being held. */
+    uint8_t previous_local = state->local_mouse_buttons;
+
+    iface->mouse_buttons = buttons;
+    refresh_local_mouse_buttons(state);
+    values.buttons       = state->mouse_buttons;
+
+    /* The other board needs our half of the union to build the same answer, having no
+       other way to hear about a button held on a device attached to us. Only when it
+       changes: movement is continuous, buttons are not, and the heartbeat restates it once
+       a second anyway. */
+    if (state->local_mouse_buttons != previous_local)
+        send_value(state->local_mouse_buttons, MOUSE_BUTTONS_MSG);
 
     /* Calculate and update mouse pointer movement. */
     enum screen_pos_e switch_direction = update_mouse_position(state, &values);

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -159,10 +159,16 @@ void heartbeat_output_task(device_t *state) {
         reset_usb_boot(1 << PICO_DEFAULT_LED_PIN, 0);
 #endif
 
+    /* Worked out again rather than read out of state->local_mouse_buttons, because that
+       copy is only refreshed when a mouse report arrives and an interface can also just go
+       away (tuh_hid_umount_cb). Sent whether it changed or not: MOUSE_BUTTONS_MSG carries
+       the edge, and this is the level that repairs a dropped one or a board that came back
+       up since. */
     uart_packet_t packet = {
         .type = HEARTBEAT_MSG,
         .data16 = {
             [0] = state->_running_fw.version,
+            [1] = refresh_local_mouse_buttons(state),
             [2] = state->active_output,
         },
     };

--- a/src/uart.c
+++ b/src/uart.c
@@ -63,6 +63,7 @@ const uart_handler_t uart_handler[] = {
     {.type = KEYBOARD_REPORT_MSG, .handler = handle_keyboard_uart_msg},
     {.type = MOUSE_REPORT_MSG, .handler = handle_mouse_abs_uart_msg},
     {.type = OUTPUT_SELECT_MSG, .handler = handle_output_select_msg},
+    {.type = MOUSE_BUTTONS_MSG, .handler = handle_mouse_buttons_msg},
 
     /* Box control */
     {.type = MOUSE_ZOOM_MSG, .handler = handle_mouse_zoom_msg},


### PR DESCRIPTION
## Summary

Two pointing devices used at once cancel each other's buttons. Holding a button on one and
moving with the other lets go of the button, so you cannot select text or drag. Fixes #287.

## Root cause

A mouse report carries the full button state of the device that sent it, and the newest
report won:

```c
/* update_mouse_position */
state->mouse_buttons = values->buttons;
```

A trackball reporting movement with nothing pressed says "no buttons" just as clearly as a
keyboard's mouse keys say "left down", so it wins by reporting second. With a pointing
device on each board the report arriving over the link overwrote the state too.

Keyboards already avoid this. `combine_kbd_states` keeps what each keyboard holds and ORs
them into one report. Mice had no equivalent.

## Changes

`hid_interface_t` gains a `mouse_buttons` byte for what that device holds, and
`process_mouse_report` sends the OR across every interface. It sits on the interface rather
than in an array keyed by the device number, because `tuh_hid_report_received_cb` gives
every mouse interface index 1 and two mice would share the slot. It also means the `memset`
already in `tuh_hid_umount_cb` clears a device's buttons when it is unplugged.

Neither board sees the other's reports, so each announces its own half in a new
`MOUSE_BUTTONS_MSG` when that half changes, and holds `local | remote`. That also lets the
rule which refuses an output switch while a button is held see a button held on the other
board.

Since the announcement only arrives on a change, the heartbeat carries the same value as a
level once a second. Without it, a dropped packet or a board that restarted mid-drag would
leave the other side holding a button nobody is pressing. Older firmware leaves the field
zero, which is correct for a board that never announces buttons, and ignores it coming the
other way.

Two smaller decode fixes come with it. The fallback for a device that declares buttons
under their own report ID, as the Kensington Expert Mouse does, now reads that interface's
last state instead of the union, which would otherwise leave one device holding another's
buttons. And the value is narrowed to the byte the outgoing report carries before it is
compared or stored, so a sixteen button device is not kept at full width only to be
truncated later.

No config, webconfig or flash layout changes. One new packet type.

## Testing

On hardware with two mice, one in the keyboard port and one in the mouse port: holding a
button on one and moving with the other now works as expected.

Builds clean with no new warnings.

There is also a host side test that links `src/mouse.c` against stubs under ASan and UBSan
and drives two interfaces through `process_mouse_report`:
[test_mouse.c](https://github.com/mglushko/deskhop-extended/blob/main/misc/hosttest/test_mouse.c).
It covers the reported case, two devices holding different buttons, unplugging one
mid-hold, a device with more buttons than the report can carry, what the announcement
carries, and the switch being held back by a button on either board.

## Note on #357

The packet numbers do not collide. #357 uses 26 and this uses 27, which is why this one
skips 26, so the two can land in either order without renumbering. There may still be a
small textual fixup in the files they both touch, depending on merge order.

They are complementary: #357 fixes the cursor position when a pointing device is attached
to each board, this fixes the buttons for the same setup. Neither depends on the other.
