### PR TITLE
Look receivers up by report ID value, so a mouse on report ID 26 works (#367)

### DIFF
--- a/src/hid_report.c
+++ b/src/hid_report.c
@@ -160,6 +160,34 @@ static uint8_t *get_next_keyboard_id(hid_interface_t *iface) {
 }
 
 
+/* The receiver bound to a report ID on this interface, or NULL if no collection on the interface
+   declared that ID. Searched by value, see report_handler_t. */
+process_report_f get_report_handler(const hid_interface_t *iface, uint8_t report_id) {
+    for (int i = 0; i < iface->num_report_handlers; i++) {
+        if (iface->report_handlers[i].report_id == report_id)
+            return iface->report_handlers[i].receiver;
+    }
+
+    return NULL;
+}
+
+/* Bind a receiver to a report ID, replacing whatever the ID was bound to before: when two
+   collections share an ID, the one parsed last wins, as it always has. */
+static void set_report_handler(hid_interface_t *iface, uint8_t report_id, process_report_f receiver) {
+    for (int i = 0; i < iface->num_report_handlers; i++) {
+        if (iface->report_handlers[i].report_id == report_id) {
+            iface->report_handlers[i].receiver = receiver;
+            return;
+        }
+    }
+
+    if (iface->num_report_handlers < MAX_REPORTS) {
+        iface->report_handlers[iface->num_report_handlers].report_id = report_id;
+        iface->report_handlers[iface->num_report_handlers].receiver  = receiver;
+        iface->num_report_handlers++;
+    }
+}
+
 void extract_data(hid_interface_t *iface, report_val_t *val) {
     const usage_map_t map[] = {
         {.usage_page   = HID_USAGE_PAGE_BUTTON,
@@ -236,8 +264,7 @@ void extract_data(hid_interface_t *iface, report_val_t *val) {
 
             hay->handler(val, hay->dst, iface);
 
-            if (val->report_id < MAX_REPORTS)
-                iface->report_handler[val->report_id] = hay->receiver;
+            set_report_handler(iface, val->report_id, hay->receiver);
         }
     }
 }

--- a/src/include/hid_parser.h
+++ b/src/include/hid_parser.h
@@ -138,13 +138,23 @@ typedef struct {
     bool is_array;
 } report_t;
 
+/* Which receiver decodes the reports carrying a given report ID. Matched by value: an ID is any
+   byte, so a table indexed by it would need 256 entries per interface, and one of MAX_REPORTS
+   entries indexed that way silently dropped every collection on an ID of MAX_REPORTS or more.
+   Packed, like report_val_t: there are MAX_DEVICES * MAX_INTERFACES of these tables. */
+typedef struct TU_ATTR_PACKED {
+    uint8_t report_id;
+    process_report_f receiver;
+} report_handler_t;
+
 struct hid_interface_t {
     keyboard_t keyboards[MAX_KEYBOARDS];
     uint8_t num_keyboards;
     mouse_t mouse;
     report_t consumer;
     report_t system;
-    process_report_f report_handler[MAX_REPORTS];
+    report_handler_t report_handlers[MAX_REPORTS];
+    uint8_t num_report_handlers;
     uint8_t protocol;
     bool uses_report_id;
 };

--- a/src/include/mouse.h
+++ b/src/include/mouse.h
@@ -17,6 +17,7 @@
  *  Data Extraction
  *==============================================================================*/
 void      extract_data(hid_interface_t *, report_val_t *);
+process_report_f get_report_handler(const hid_interface_t *, uint8_t);
 int32_t   get_report_value(uint8_t *, int, report_val_t *);
 void      parse_report_descriptor(hid_interface_t *, uint8_t const *, int);
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -251,12 +251,10 @@ void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t cons
         if (iface->uses_report_id)
             report_id = report[0];
 
-        if (report_id < MAX_REPORTS) {
-            process_report_f receiver = iface->report_handler[report_id];
+        process_report_f receiver = get_report_handler(iface, report_id);
 
-            if (receiver != NULL)
-                receiver((uint8_t *)report, len, device_idx, iface);
-        }
+        if (receiver != NULL)
+            receiver((uint8_t *)report, len, device_idx, iface);
     }
     else if (itf_protocol == HID_ITF_PROTOCOL_KEYBOARD) {
         process_keyboard_report((uint8_t *)report, len, device_idx, iface);


### PR DESCRIPTION
## Summary

The Microsoft Sculpt Ergonomic Mouse does nothing through DeskHop: no cursor and no clicks, in report protocol or boot. Its receiver puts the mouse on report ID 0x1A, which is 26, and the table that routes reports to their decoder has 24 slots indexed by the ID. Fixes #367.

## Root cause

`hid_interface_t` records which function decodes each report ID in

```c
process_report_f report_handler[MAX_REPORTS];   /* MAX_REPORTS is 24 */
```

indexed by the ID itself. Both the binding in `extract_data()` and the lookup in `tuh_hid_report_received_cb` are guarded by `report_id < MAX_REPORTS`, so for report 0x1A nothing is ever bound and every report is dropped before it is decoded. The parser is not at fault: it puts the buttons, the 16-bit X and Y, the wheel and the pan at exactly the right offsets. The reporter's own workaround in the issue, an early return on `report[0] == 0x1A`, works for the same reason, by stepping around the table.

The Apple keyboard in #157 has the same shape, with its media keys on report 0x52, and would lose them the same way.

## Changes

The table becomes a list of (report ID, receiver) pairs searched by value, the way `parser_state_t.report_offsets` already is in the parser. `get_report_handler()` does the lookup for usb.c and `set_report_handler()` the binding for `extract_data()`. Two collections on one ID still resolve to whichever was parsed last, as before, and `MAX_REPORTS` now bounds how many distinct IDs an interface can bind rather than how large an ID may be. The pair is packed like `report_val_t`, so the change costs 22 bytes per interface, about 1 KB across `global_state`.

One consequence worth knowing: the Sculpt's second collection, AC Pan under a Consumer Control application on report 0x1F, is bound as well now, to the consumer path. Every frame captured from the receiver was 0x1A, so it may never be sent.

No config, webconfig or flash layout changes.

## Testing

Against the 50 descriptors in [deskhop-hidtests](https://github.com/mglushko/deskhop-hidtests), which runs the firmware's own `hid_parser.c` and `hid_report.c` on the host: the Sculpt is the only descriptor whose parse changes, its report 0x1A going from bound to nothing to bound to the mouse path, and every other device parses byte for byte as on main. All twelve reports the reporter captured, moves, clicks, wheel and tilt, decode to the values they carry. The routing check goes from dropped to delivered for that report. The same check still shows a mouse in boot protocol being routed by its button byte, which is a separate matter and not touched here.

On hardware, a spare RP2040 presenting the receiver's three interfaces byte for byte, plugged into a DeskHop board running a build with this change: it traces a circle, presses all five buttons, and scrolls both axes with the right signs and magnitudes. On main the harness shows the same reports reaching no receiver.

Builds clean with no new warnings.

I do not own the mouse, so the rig is built from the dumps in the issue rather than the real thing. Happy to change anything here.
